### PR TITLE
rkt: mounting tmpfs directories

### DIFF
--- a/rkt/path.go
+++ b/rkt/path.go
@@ -24,6 +24,16 @@ func Stage1InitPath(root string) string {
 	return filepath.Join(root, stage1Init)
 }
 
+// Stage1TmpPath returns the path to a directory used as a shared
+// tmpfs among apps in a rocket container
+func Stage1TmpfsPath(root string) string {
+	s, err := filepath.Abs(root)
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(s, "/tmp")
+}
+
 // ContainerManifestPath returns the path in root to the Container Runtime Manifest
 func ContainerManifestPath(root string) string {
 	return filepath.Join(root, "container")

--- a/stage1/init.go
+++ b/stage1/init.go
@@ -47,7 +47,19 @@ func main() {
 		args = append(args, "--quiet") // silence most nspawn output (log_warning is currently not covered by this)
 	}
 
-	nsargs, err := c.ContainerToNspawnArgs()
+	// Set up a shared tmpdir for the container
+	tmp := rkt.Stage1TmpfsPath(c.Root)
+	if tmp == "" {
+		// should never happen
+		fmt.Fprintf(os.Stderr, "Failed to generate tmpdir path")
+		os.Exit(2)
+	}
+	if err := os.MkdirAll(tmp, 1777); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create tmpdir: %v\n", err)
+		os.Exit(2)
+	}
+
+	nsargs, err := c.ContainerToNspawnArgs(tmp)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to generate nspawn args: %v\n", err)
 		os.Exit(4)


### PR DESCRIPTION
We need to mount tmpfs directories for the containers. Using PrivateTmp directive does not work with RootDirectory as far as I can tell:

```
==> "/tmp" is not a mount point
```
