### PR TITLE
downloadstore: use the download store to save files

### DIFF
--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -2,16 +2,12 @@ package main
 
 import (
 	"archive/tar"
-	"compress/bzip2"
-	"compress/gzip"
 	"fmt"
-	"io"
-	"log"
 	"os"
 	"path/filepath"
 
-	"github.com/containers/standard/schema/types"
 	"github.com/containers/standard/taf"
+	"github.com/coreos-inc/rkt/downloadstore"
 )
 
 const (
@@ -37,56 +33,35 @@ func runFetch(args []string) (exit int) {
 		fmt.Fprintf(os.Stderr, "fetch: error creating image directory: %v", err)
 		return 1
 	}
+
+	ds := downloadstore.NewDownloadStore(globalFlags.Dir)
+
 	for _, img := range args {
-		h, err := types.NewHash(img)
-		if err != nil {
-			log.Fatalf("bad hash given: %v", err)
-		}
-		rs := fetchImage(h.String())
-		typ, err := taf.DetectFileType(rs)
-		if err != nil {
-			log.Fatalf("error detecting image type: %v", err)
-		}
-		if _, err := rs.Seek(0, 0); err != nil {
-			log.Fatalf("error seeking image: %v", err)
-		}
-		var r io.Reader
-		switch typ {
-		case taf.TypeGzip:
-			r, err = gzip.NewReader(rs)
+		rem := downloadstore.NewRemote(img, []string{})
+		err := ds.Get(rem)
+		if err != nil && rem.File == "" {
+			rem, err = rem.Download(*ds)
 			if err != nil {
-				log.Fatalf("error reading gzip: %v", err)
+				fmt.Fprintf(os.Stderr, "downloading: %v\n", err)
 			}
-		case taf.TypeBzip2:
-			r = bzip2.NewReader(rs)
-		case taf.TypeXz:
-			r = taf.XzReader(rs)
-		case taf.TypeUnknown:
-			log.Fatalf("error: unknown image filetype")
-		default:
-			// should never happen
-			panic("no type returned from DetectFileType?")
 		}
-		tr := tar.NewReader(r)
-		dir := filepath.Join(root, h.String())
+		rs, err := ds.ObjectStream(rem.File)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error fetching: %v\n", err)
+			return 1
+		}
+
+		tr := tar.NewReader(rs)
+		dir := filepath.Join(root, "sha256-"+rem.File)
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			fmt.Fprintf(os.Stderr, "fetch: error creating image directory: %v", err)
 			return 1
 		}
 		if err := taf.ExtractTar(tr, dir); err != nil {
 			fmt.Fprintf(os.Stderr, "fetch: error extracting tar: %v", err)
+			return 1
 		}
+		fmt.Println(rem.File)
 	}
 	return
-}
-
-// fetchImage returns an io.ReadSeeker accessing the image of the given hash.
-// Right now it simply pulls from a local file on disk, but in future it would
-// retrieve from a web service or similar.
-func fetchImage(hash string) io.ReadSeeker {
-	fh, err := os.Open(hash)
-	if err != nil {
-		log.Fatalf("error opening image: %v", err)
-	}
-	return fh
 }

--- a/downloadstore/cas_test.go
+++ b/downloadstore/cas_test.go
@@ -1,4 +1,4 @@
-package main
+package downloadstore
 
 import (
 	"fmt"

--- a/downloadstore/remote.go
+++ b/downloadstore/remote.go
@@ -1,12 +1,17 @@
-package main
+package downloadstore
 
 import (
 	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+
+	"github.com/containers/standard/taf"
 )
 
 func NewRemote(name string, mirrors []string) *Remote {
@@ -44,10 +49,33 @@ func (r Remote) Type() int64 {
 	return remoteType
 }
 
+func decompress(rs io.Reader, typ taf.FileType) (io.Reader, error) {
+	var (
+		dr io.Reader
+		err error
+	)
+	switch typ {
+	case taf.TypeGzip:
+		dr, err = gzip.NewReader(rs)
+		if err != nil {
+			return nil, err
+		}
+	case taf.TypeBzip2:
+		dr = bzip2.NewReader(rs)
+	case taf.TypeXz:
+		dr = taf.XzReader(rs)
+	case taf.TypeUnknown:
+		fmt.Fprintf(os.Stderr, "error: unknown image filetype\n")
+	default:
+		// should never happen
+		panic("no type returned from DetectFileType?")
+	}
+	return dr, nil
+}
+
 // TODO: add locking
 func (r Remote) Download(ds DownloadStore) (*Remote, error) {
 	var b bytes.Buffer
-	hash := sha256.New()
 
 	res, err := http.Get(r.Name)
 	if err != nil {
@@ -55,8 +83,9 @@ func (r Remote) Download(ds DownloadStore) (*Remote, error) {
 	}
 	defer res.Body.Close()
 
-	// TODO: use go routines to parallelize this pipeline
-	_, err = io.Copy(&b, io.TeeReader(res.Body, hash))
+	// TODO(philips): use go routines to parallelize this pipeline and make
+	// the file type detection happen without a second stream
+	_, err = io.Copy(&b, res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -65,12 +94,46 @@ func (r Remote) Download(ds DownloadStore) (*Remote, error) {
 		return nil, err
 	}
 
+	// Detect the filetype
 	rs, err := ds.stores[downloadType].ReadStream(r.Hash(), false)
 	if err != nil {
 		return nil, err
 	}
-	key := fmt.Sprintf("%x", hash.Sum(nil))
-	err = ds.stores[objectType].WriteStream(key, rs, true)
+	defer rs.Close()
+	typ, err := taf.DetectFileType(rs)
+	if err != nil {
+		return nil, err
+	}
+	rs, err = ds.stores[downloadType].ReadStream(r.Hash(), false)
+	if err != nil {
+		return nil, err
+	}
+	defer rs.Close()
+
+	// Generate the hash of the decompressed tar
+	dr, err := decompress(rs, typ)
+	if err != nil {
+		return nil, err
+	}
+	hash := sha256.New()
+	_, err = io.Copy(hash, dr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store the decompressed tar
+	rs, err = ds.stores[downloadType].ReadStream(r.Hash(), false)
+	if err != nil {
+		return nil, err
+	}
+	defer rs.Close()
+	dr, err = decompress(rs, typ)
+	if err != nil {
+		return nil, err
+	}
+
+	key := fmt.Sprintf("sha256-%x", hash.Sum(nil))
+	err = ds.stores[objectType].WriteStream(key, dr, true)
 	if err != nil {
 		return nil, err
 	}

--- a/downloadstore/utils.go
+++ b/downloadstore/utils.go
@@ -1,24 +1,28 @@
-package main
+package downloadstore
 
 import (
 	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/url"
+	"strings"
 )
 
 // copy the default of git which is a two byte prefix. We will likely want to
 // add re-sharding later.
 func blockTransform(s string) []string {
-	pathSlice := make([]string, 1)
-	pathSlice[0] = s[0:2]
+	// TODO(philips): use spec/types.Hash after export typ field
+	parts := strings.SplitN(s, "-", 2)
+	pathSlice := make([]string, 2)
+	pathSlice[0] = parts[0]
+	pathSlice[1] = parts[1][0:2]
 	return pathSlice
 }
 
 func sha256sum(s string) string {
 	h := sha256.New()
 	io.WriteString(h, s)
-	return fmt.Sprintf("%x", h.Sum(nil))
+	return fmt.Sprintf("sha256-%x", h.Sum(nil))
 }
 
 func parseAlways(s string) *url.URL {

--- a/examples/dsfetch/main.go
+++ b/examples/dsfetch/main.go
@@ -1,13 +1,15 @@
-package main
+package downloadstore
 
 import (
 	"fmt"
 	"log"
 	"os"
+
+	"github.com/coreos-inc/rkt/downloadstore"
 )
 
 func main() {
-	ds := NewDownloadStore()
+	ds := NewDownloadStore(".")
 	r := NewRemote(os.Args[1], nil)
 	err := ds.Get(r)
 	if err != nil && r.File == "" {


### PR DESCRIPTION
```
rkt fetch https://storage-download.googleapis.com/users.developer.core-os.net/philips/validator/ace_validator_main.tar.gz
find /var/lib/rkt
/var/lib/rkt
/var/lib/rkt/cas
/var/lib/rkt/cas/download
/var/lib/rkt/cas/object
/var/lib/rkt/cas/object/f5
/var/lib/rkt/cas/object/f5/f59cb373728bd0f73674cc0b50286e56ba15bdd15a9e4ce8ccca18d0b6034ce8
/var/lib/rkt/cas/remote
/var/lib/rkt/cas/remote/88
/var/lib/rkt/cas/remote/88/883fbbdc30767d532af458df6146577761f40997ffa5c7a8ea91045cede8f197
/var/lib/rkt/images
/var/lib/rkt/images/sha256-f59cb373728bd0f73674cc0b50286e56ba15bdd15a9e4ce8ccca18d0b6034ce8
/var/lib/rkt/images/sha256-f59cb373728bd0f73674cc0b50286e56ba15bdd15a9e4ce8ccca18d0b6034ce8/manifest
/var/lib/rkt/images/sha256-f59cb373728bd0f73674cc0b50286e56ba15bdd15a9e4ce8ccca18d0b6034ce8/rootfs
/var/lib/rkt/images/sha256-f59cb373728bd0f73674cc0b50286e56ba15bdd15a9e4ce8ccca18d0b6034ce8/rootfs/ace_validator
```
