### PR TITLE
appc: expand `actool validate` autodetect

### DIFF
--- a/app-container/actool/validate.go
+++ b/app-container/actool/validate.go
@@ -1,25 +1,43 @@
 package main
 
 import (
+	"archive/tar"
 	"compress/bzip2"
 	"compress/gzip"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
-	"path/filepath"
+	"strings"
 
 	"github.com/coreos-inc/rkt/app-container/aci"
+	"github.com/coreos-inc/rkt/app-container/fileset"
 	"github.com/coreos-inc/rkt/app-container/schema"
 )
 
-var cmdValidate = &Command{
-	Name:        "validate",
-	Description: "Validate an AppContainer file",
-	Summary:     "Validate an AppContainer file",
-	Run:         runValidate,
+const (
+	typeAppImage = "appimage"
+	typeManifest = "manifest"
+)
+
+var (
+	valType     string
+	cmdValidate = &Command{
+		Name:        "validate",
+		Description: "Validate an AppContainer file",
+		Summary:     "Validate an AppContainer file",
+		Run:         runValidate,
+	}
+	types = []string{
+		typeAppImage,
+		typeManifest,
+	}
+)
+
+func init() {
+	cmdValidate.Flags.StringVar(&valType, "type", "",
+		fmt.Sprintf(`Type of file to validate. If unset, actool will try to detect the type. One of "%s"`, strings.Join(types, ",")))
 }
 
 func runValidate(args []string) (exit int) {
@@ -31,43 +49,64 @@ func runValidate(args []string) (exit int) {
 	for _, path := range args {
 		file, err := os.OpenFile(path, os.O_RDONLY, 0666)
 		if err != nil {
-			stderr("unable to open %s: %v\n", path, err)
+			stderr("unable to open %s: %v", path, err)
 			return 1
 		}
 
-		// First key off extension, and then possibly fall back to
-		switch filepath.Ext(path) {
-		case schema.ACIExtension:
-			err := validateACI(file)
+		if valType == "" {
+			valType, err = detectValType(file)
+			if err != nil {
+				stderr("error detecting file type: %v", err)
+				return 1
+			}
+		}
+		switch valType {
+		case typeAppImage:
+			tr := tar.NewReader(file)
+			err := fileset.ValidateArchive(tr)
+			//			err := validateACI(file)
 			file.Close()
 			if err != nil {
-				stderr("%s: error validating: %v\n", path, err)
+				stderr("%s: error validating: %v", path, err)
 				return 1
 			}
 			if globalFlags.Debug {
-				stderr("%s: valid aci\n", path)
+				stderr("%s: valid fileset", path)
 			}
 			continue
-		}
-
-		b, err := ioutil.ReadFile(path)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: unable to read file %s\n", path, err)
-			return 1
-		}
-
-		typ := http.DetectContentType(b)
-		switch {
-		case typ == "text/plain; charset=utf-8":
-			// TODO(philips): validate schema, need a package to take a ACKind
-			// and lookup the validator
+		case typeManifest:
+			b, err := ioutil.ReadAll(file)
+			file.Close()
+			if err != nil {
+				stderr("%s: unable to read file %s", path, err)
+				return 1
+			}
 			k := schema.Kind{}
-			k.UnmarshalJSON(b)
-			if globalFlags.Debug {
-				fmt.Fprintf(os.Stderr, "%s: valid %s\n", path, k.ACKind)
+			if err := k.UnmarshalJSON(b); err != nil {
+				stderr("error unmarshaling manifest: %v", err)
+				return 1
+			}
+			switch k.ACKind {
+			case "AppManifest":
+				m := schema.AppManifest{}
+				err = m.UnmarshalJSON(b)
+			case "ContainerRuntimeManifest":
+				m := schema.ContainerRuntimeManifest{}
+				err = m.UnmarshalJSON(b)
+			case "FileSetManifest":
+				m := schema.FileSetManifest{}
+				err = m.UnmarshalJSON(b)
+			default:
+				// Should not get here; schema.Kind unmarshal should fail
+				panic("bad ACKind")
+			}
+			if err != nil {
+				stderr("%s: invalid %s: %v", path, k.ACKind, err)
+			} else if globalFlags.Debug {
+				stderr("%s: valid %s", path, k.ACKind)
 			}
 		default:
-			fmt.Fprintf(os.Stderr, "%s: unknown filetype %s\n", path, typ)
+			stderr("%s: unable to detect filetype (try --type)", path)
 			return 1
 		}
 	}
@@ -75,7 +114,26 @@ func runValidate(args []string) (exit int) {
 	return
 }
 
+func detectValType(file *os.File) (string, error) {
+	typ, err := aci.DetectFileType(file)
+	if err != nil {
+		return "", err
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		return "", err
+	}
+	switch typ {
+	case aci.TypeXz, aci.TypeGzip, aci.TypeBzip2, aci.TypeTar:
+		return typeAppImage, nil
+	case aci.TypeText:
+		return typeManifest, nil
+	default:
+		return "", nil
+	}
+}
+
 func validateACI(rs io.ReadSeeker) error {
+	// TODO(jonboulle): this is a bit redundant with detectValType
 	typ, err := aci.DetectFileType(rs)
 	if err != nil {
 		return err
@@ -98,7 +156,7 @@ func validateACI(rs io.ReadSeeker) error {
 		return errors.New("unknown filetype")
 	default:
 		// should never happen
-		panic("no type returned from DetectFileType?")
+		panic(fmt.Sprintf("bad type returned from DetectFileType: %v", typ))
 	}
 	return aci.ValidateTar(r)
 }

--- a/app-container/schema/types/ackind.go
+++ b/app-container/schema/types/ackind.go
@@ -21,7 +21,7 @@ func (a ACKind) String() string {
 func (a ACKind) assertValid() error {
 	s := a.String()
 	switch s {
-	case "AppManifest", "ContainerRuntimeManifest", "CASAppFormatManifest", "FileSetManifest":
+	case "AppManifest", "ContainerRuntimeManifest", "FileSetManifest":
 		return nil
 	case "":
 		return ErrNoACKind


### PR DESCRIPTION
No longer considering file extensions, now sniffing all types:
- if tar/gz/xz/bz2, attempt to validate as an ACI
- if utf-8/text, detect ACKind and then validate as respective manifest
  type
- users can override detection with `--type` flag
