### PR TITLE
appc/actool: support building non-fileset app images

### DIFF
--- a/app-container/ace/build_aci
+++ b/app-container/ace/build_aci
@@ -19,10 +19,10 @@ for typ in main sidekick; do
 	pushd ${layoutdir} >/dev/null
 		# Set a consistent timestamp so we get a consistent hash
 		# TODO(jonboulle): make this cleaner..
-		for path in app rootfs rootfs/ace_validator; do
+		for path in rootfs rootfs/ace_validator; do
 			touch -a -m -d 1415660606 ${path}
 		done
-		../actool build --overwrite --name coreos.com/ace-validator-${typ}-1.0.0 . ../ace_validator_${typ}.aci
+		../actool build --overwrite --app-manifest app rootfs/ ../ace_validator_${typ}.aci
 		HASH=sha256-$(sha256sum ../ace_validator_${typ}.aci|awk '{print $1}')
 		gzip -f ../ace_validator_${typ}.aci
 		mv ../ace_validator_${typ}.aci.gz ../ace_validator_${typ}.aci


### PR DESCRIPTION
Putting this up as a bit of a UX strawman. One "problem" with this right now is that it deserializes and reserializes the app manifest which means what gets written into the ACI is different from what the user originally supplies. Not sure whether this is a feature or a bug.
