### PR TITLE
appc: consolidate validation code

### DIFF
--- a/app-container/aci/writer.go
+++ b/app-container/aci/writer.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/coreos-inc/rkt/app-container/schema"
@@ -73,7 +74,10 @@ func (aw *appArchiveWriter) AddFile(path string, hdr *tar.Header, r io.Reader) e
 }
 
 func (aw *fsArchiveWriter) AddFile(path string, hdr *tar.Header, r io.Reader) error {
-	aw.fsm.Files = append(aw.fsm.Files, path)
+	relpath := strings.TrimPrefix(path, "rootfs")
+	if relpath != "/" {
+		aw.fsm.Files = append(aw.fsm.Files, relpath)
+	}
 	return aw.appArchiveWriter.AddFile(path, hdr, r)
 }
 

--- a/app-container/actool/validate.go
+++ b/app-container/actool/validate.go
@@ -99,7 +99,6 @@ func runValidate(args []string) (exit int) {
 			}
 			tr := tar.NewReader(fr)
 			err = aci.ValidateArchive(tr)
-			// err = aci.ValidateTar(r)
 			fh.Close()
 			if err != nil {
 				stderr("%s: error validating: %v", path, err)


### PR DESCRIPTION
This (finally) consolidates the code for validating app images and Fileset
images, and also between tars/directories.

It also fixes a few small path issues with fileset generation: the list of
files in a fileset should ONLY include those in the rootfs/ directory, and
their names should be relative to the rootfs
