### PR TITLE
fix json typos

### DIFF
--- a/app-container/SPEC.md
+++ b/app-container/SPEC.md
@@ -555,13 +555,13 @@ JSON Schema for the App Image Manifest
             "hash": "sha256-...",
             "name": "example.com/trusted-certificate-authority-1.0.0",
             "root": "/etc/ca"
-        },
+        }
     ],
     "files": [
         "/etc/ca/example.com/crt",
         "/usr/bin/map-reduce-worker",
         "/opt/libs/reduce-toolkit.so",
-        "/etc/reduce-worker.conf",
+        "/etc/reduce-worker.conf"
     ]
 }
 ```


### PR DESCRIPTION
docs: removed extra ,'s 

incorrect json format
