### PR TITLE
metadatasvc: wrapped initCrypto with log.Fatal

### DIFF
--- a/metadatasvc/main.go
+++ b/metadatasvc/main.go
@@ -378,7 +378,7 @@ func logReq(h func(w http.ResponseWriter, r *http.Request)) func(w http.Response
 
 func main() {
 	if err := setupIPTables(); err != nil {
-		fmt.Fatal(err)
+		log.Fatal(err)
 	}
 
 	if err := initCrypto(); err != nil {


### PR DESCRIPTION
In case the HMAC key generation fails then do not allow the metadatasvc process execution to continue and print the error.
This avoids any potential security issues if there is not enough entropy in the system.
