### PR TITLE
provide prefix for mktemp

### DIFF
--- a/build
+++ b/build
@@ -26,7 +26,7 @@ S1BINS=${PWD}/stage0
 S1INIT=${S1BINS}/stage1_init
 if [ $GOBIN/init -nt $S1INIT/bin.go ]; then
 	echo "Packaging init (stage1)..."
-	TMP=$(mktemp -d)
+	TMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'rocket.XXXXX')
 	[ -d $S1INIT ] || mkdir -p $S1INIT
 	cp $GOBIN/init $TMP/s1init
 	go-bindata -o $S1INIT/bin.go -pkg="stage1_init" -prefix=$TMP $TMP


### PR DESCRIPTION
mktemp support is trivial.  However, the number of linux commands makes this process very linux dependent.

unsquashfs (no known cross-os tool)
http://zettelchen.blogspot.com/2009/04/build-squashfs-tools-for-mac-os-x.html

( could easily be done with another command, I would think)
brew tap iveney/mocha && brew install realpath

After installing these tools, rkt appeared to work. OS X Yosemite

```
$ rkt fetch https://github.com/coreos/etcd/releases/download/v0.5.0-alpha.4/etcd-v0.5.0-alpha.4-linux-amd64.aci
sha256-701c24b2d275f0e291b807a464ae2390bcd8d7c5b4f2d7e47e6fd917cd5e5588
```
