### PR TITLE
tests: add travis-ci config and test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+# Configures Rocket tests at Travis CI (https://travis-ci.org).
+
+language: go
+
+go:
+ - 1.3
+
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -y cpio realpath squashfs-tools
+
+install:
+ - go get code.google.com/p/go.tools/cmd/cover
+ - go get code.google.com/p/go.tools/cmd/vet
+ - go get github.com/jteeuwen/go-bindata/...
+
+script:
+ - ./test
+

--- a/app-container/discovery/parse.go
+++ b/app-container/discovery/parse.go
@@ -16,8 +16,8 @@ const (
 )
 
 type App struct {
-	Name    types.ACName
-	Labels  map[string]string
+	Name   types.ACName
+	Labels map[string]string
 }
 
 func NewApp(name string, labels map[string]string) (*App, error) {
@@ -29,8 +29,8 @@ func NewApp(name string, labels map[string]string) (*App, error) {
 		return nil, err
 	}
 	return &App{
-		Name:    *acn,
-		Labels:  labels,
+		Name:   *acn,
+		Labels: labels,
 	}, nil
 }
 
@@ -41,8 +41,8 @@ func NewApp(name string, labels map[string]string) (*App, error) {
 // 	example.com/reduce-worker,channel=alpha,label=value
 func NewAppFromString(app string) (*App, error) {
 	var (
-		name string
-		labels        map[string]string
+		name   string
+		labels map[string]string
 	)
 
 	app = strings.Replace(app, ":", ",version=", -1)

--- a/app-container/examples/app.json
+++ b/app-container/examples/app.json
@@ -1,4 +1,5 @@
 {
+    "acVersion": "1.0.0",
     "acKind": "AppManifest",
     "name": "example.com/reduce-worker",
     "version": "1.0.0",

--- a/pkg/tarheader/pop_posix.go
+++ b/pkg/tarheader/pop_posix.go
@@ -10,7 +10,6 @@ func init() {
 	populateHeaderStat = append(populateHeaderStat, populateHeaderUnix)
 }
 
-
 func populateHeaderUnix(h *tar.Header, fi os.FileInfo) {
 	st, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {

--- a/test
+++ b/test
@@ -1,0 +1,63 @@
+#!/bin/bash -e
+#
+# Run all rocket tests
+# ./test
+# ./test -v
+#
+# Run tests for one package
+#
+# PKG=./app-container/discovery ./test
+# PKG=cas ./test
+
+# Invoke ./cover for HTML output
+COVER=${COVER:-"-cover"}
+
+source ./build
+
+TESTABLE_AND_FORMATTABLE="app-container/discovery app-container/schema/types cas pkg/tar"
+FORMATTABLE="$TESTABLE_AND_FORMATTABLE app-container/ace app-container/aci app-container/actool app-container/schema metadatasvc path pkg/io pkg/proc pkg/tarheader rkt stage0/run.go stage1 version"
+
+# user has not provided PKG override
+if [ -z "$PKG" ]; then
+	TEST=$TESTABLE_AND_FORMATTABLE
+	FMT=$FORMATTABLE
+
+# user has provided PKG override
+else
+	# strip out leading dotslashes and trailing slashes from PKG=./foo/
+	TEST=${PKG/#./}
+	TEST=${TEST/#\//}
+	TEST=${TEST/%\//}
+
+	# only run gofmt on packages provided by user
+	FMT="$TEST"
+fi
+
+# split TEST into an array and prepend REPO_PATH to each local package
+split=(${TEST// / })
+TEST=${split[@]/#/${REPO_PATH}/}
+
+echo "Running tests..."
+go test -timeout 60s ${COVER} $@ ${TEST} --race
+
+echo "Validating app manifest..."
+bin/actool validate app-container/examples/app.json
+
+echo "Validating container runtime manifest..."
+bin/actool validate app-container/examples/container.json
+
+echo "Checking gofmt..."
+fmtRes=$(gofmt -l $FMT)
+if [ -n "${fmtRes}" ]; then
+	echo -e "gofmt checking failed:\n${fmtRes}"
+	exit 255
+fi
+
+echo "Checking govet..."
+vetRes=$(go vet $TEST)
+if [ -n "${vetRes}" ]; then
+	echo -e "govet checking failed:\n${vetRes}"
+	exit 255
+fi
+
+echo "Success"


### PR DESCRIPTION
This adds a .travis.yml file to run the app-container tests, although it points out currently that one of them needs to be updated:

``` console
$ go test -v ./app-container/...
# github.com/coreos/rocket/app-container/discovery
app-container/discovery/discovery_test.go:33: too many arguments in call to DiscoverEndpoints
```

I didn't include go 1.2 in the matrix because it has a separate error during the `install` task, and I wasn't sure if 1.2 support was required:

``` console
$ go get -d -v ./app-container/... && go build -v ./app-container/...
github.com/coreos/rocket (download)
# github.com/coreos/rocket/app-container/ace
app-container/ace/validator.go:214: unknown http.Client field 'Timeout' in struct literal
```

Refs #169. Requires the Travis CI webhook to be enabled, either in GitHub's project settings, or by toggling it on in Travis CI's settings page (easier, IMHO).

See http://docs.travis-ci.com/user/languages/go/ for details of how to configure go tests at Travis CI.
