### PR TITLE
Fix creation of HardLinks.

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -43,11 +43,11 @@ func ExtractTar(tr *tar.Reader, dir string) error {
 					return err
 				}
 			case typ == tar.TypeLink:
-				dest := filepath.Join(filepath.Dir(p), hdr.Linkname)
+				dest := filepath.Join(dir, hdr.Linkname)
 				if !strings.HasPrefix(dest, dir) {
 					return insecureLinkError(fmt.Errorf("insecure link %q -> %q", p, hdr.Linkname))
 				}
-				if err := os.Link(hdr.Linkname, p); err != nil {
+				if err := os.Link(dest, p); err != nil {
 					return err
 				}
 			case typ == tar.TypeSymlink:


### PR DESCRIPTION
Hi. Congrats for great work!

I was trying to manually create a fileset for a base fedora image using gnu tar. On rkt run I noticed that it was failing extracting the tar with an error like this:

`run: error setting up stage0: error setting up image sha256-5d12db67edc3884bf0a659390f162d83dedcadfbc8cdf96a82650adbdd871705: error extracting ACI: link ./rootfs/usr/bin/pkg-config /var/lib/rkt/containers/d1c6e082-686a-4e97-88c4-2f1df432b307/stage1/opt/stage2/sha256-5d12db67edc3884bf0a659390f162d83dedcadfbc8cdf96a82650adbdd871705/rootfs/usr/bin/x86_64-redhat-linux-gnu-pkg-config: no such file or directory`

With tar the LinkName of an hardlink is different from the one of a symlink. It's the path relative to the tar's root.
I tried to fix it.

I also fixed the security check (if something malicious creates a tar with a bad Linkname like ../../../etc/shadow)

I have some doubts (maybe a new issue will be better) on the check for the symlinks as a symlink can also be an absolute path (it's now working as the abs path is joined with the dest file dir).

Thanks!
