### PR TITLE
mkrootfs.sh: add flags for dlsym

### DIFF
--- a/stage1/mkrootfs.sh
+++ b/stage1/mkrootfs.sh
@@ -394,7 +394,7 @@ EOF
 chmod 755 "${ROOTDIR}/reaper.sh"
 
 # LD_PRELOAD shim to trick the sd_booted() "/run/systemd/system" check in systemd-nspawn
-gcc -shared -fPIC -x c -pipe -ldl -o ${ROOTDIR}/fakesdboot.so - <<'EOF'
+gcc -shared -fPIC -x c -pipe -Wl,--no-as-needed -ldl -o ${ROOTDIR}/fakesdboot.so - <<'EOF'
 #define _GNU_SOURCE
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
While running the example hello.aci, I get the error:

```
stage1/usr/bin/systemd-nspawn: symbol lookup error: stage1/fakesdboot.so: undefined symbol: dlsym
```

I'm not sure it is the best thing to do, but setting the flags `-Wl,--no-as-needed` solved my problem.

My configuration:

> Linux ubuntu 3.16.0-25-generic
> gcc version 4.9.1 (Ubuntu 4.9.1-16ubuntu6)
