### PR TITLE
build: Fix non-POSIX commands realpath and mktemp

### DIFF
--- a/build
+++ b/build
@@ -26,7 +26,7 @@ S1BINS=${PWD}/stage0
 S1INIT=${S1BINS}/stage1_init
 if [ $GOBIN/init -nt $S1INIT/bin.go ]; then
 	echo "Packaging init (stage1)..."
-	TMP=$(mktemp -d)
+	TMP=$(mktemp -d -t rocket-XXXXXX)
 	[ -d $S1INIT ] || mkdir -p $S1INIT
 	cp $GOBIN/init $TMP/s1init
 	go-bindata -o $S1INIT/bin.go -pkg="stage1_init" -prefix=$TMP $TMP

--- a/stage1/mkrootfs.sh
+++ b/stage1/mkrootfs.sh
@@ -440,5 +440,5 @@ mkdir "${BINDIR}"
 tar cf "${BINDIR}/s1rootfs.tar" -C "${ROOTDIR}" .
 OUTDIR=$(dirname "${OUTPUT}")
 [ -d "$OUTDIR" ] || mkdir -p "${OUTDIR}"
-go-bindata -o "${OUTPUT}" -prefix $(realpath "${BINDIR}") -pkg=stage1_rootfs "${BINDIR}"
+go-bindata -o "${OUTPUT}" -prefix "${PWD}${BINDIR}" -pkg=stage1_rootfs "${BINDIR}"
 rm -Rf "${WORK}"


### PR DESCRIPTION
realpath is not POSIX and not available on all systems.
POSIX mktemp requires a mandatory template argument.
