### PR TITLE
Documentation: Add 'gpg' to build pre-requisites

### DIFF
--- a/Documentation/hacking.md
+++ b/Documentation/hacking.md
@@ -8,6 +8,7 @@
   * cpio
   * squashfs-tools
   * realpath
+  * gpg
 * Go 1.3+
   * jteeuwen/go-bindata
 


### PR DESCRIPTION
Commit 00294ed ("stage1: gpg verify and cache retrieved coreos image")
added a dependency to 'gpg'. Add that to list of build pre-requisites.

Signed-off-by: Pekka Enberg penberg@cloudius-systems.com
