### PR TITLE
cas: write download progress to stdout

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/coreos/rocket",
-	"GoVersion": "go1.3.1",
+	"GoVersion": "go1.3.3",
 	"Packages": [
 		"./..."
 	],
@@ -26,6 +26,10 @@
 		{
 			"ImportPath": "github.com/gorilla/mux",
 			"Rev": "e444e69cbd2e2e3e0749a2f3c717cec491552bbf"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/ioprogress",
+			"Rev": "b0a0b6773359ef5016d5ecc4522150e43a189a53"
 		},
 		{
 			"ImportPath": "github.com/petar/GoLLRB/llrb",

--- a/Godeps/_workspace/src/github.com/mitchellh/ioprogress/LICENSE
+++ b/Godeps/_workspace/src/github.com/mitchellh/ioprogress/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Godeps/_workspace/src/github.com/mitchellh/ioprogress/README.md
+++ b/Godeps/_workspace/src/github.com/mitchellh/ioprogress/README.md
@@ -1,0 +1,42 @@
+# ioprogress
+
+ioprogress is a Go (golang) library with implementations of `io.Reader`
+and `io.Writer` that draws progress bars. The primary use case for these
+are for CLI applications but alternate progress bar writers can be supplied
+for alternate environments.
+
+## Example
+
+![Progress](http://g.recordit.co/GO5HxT16QH.gif)
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/ioprogress
+```
+
+## Usage
+
+Here is an example of outputting a basic progress bar to the CLI as
+we're "downloading" from some other `io.Reader` (perhaps from a network
+connection):
+
+```go
+// Imagine this came from some external source, such as a network connection,
+// and that we have the full size of it, such as from a Content-Length HTTP
+// header.
+var r io.Reader
+
+// Create the progress reader
+progressR := &ioprogress.Reader{
+	Reader: r,
+	Size:   rSize,
+}
+
+// Copy all of the reader to some local file f. As it copies, the
+// progressR will write progress to the terminal on os.Stdout. This is
+// customizable.
+io.Copy(f, progressR)
+```

--- a/Godeps/_workspace/src/github.com/mitchellh/ioprogress/draw.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/ioprogress/draw.go
@@ -1,0 +1,104 @@
+package ioprogress
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// DrawFunc is the callback type for drawing progress.
+type DrawFunc func(int64, int64) error
+
+// DrawTextFormatFunc is a callback used by DrawFuncs that draw text in
+// order to format the text into some more human friendly format.
+type DrawTextFormatFunc func(int64, int64) string
+
+var defaultDrawFunc DrawFunc
+
+func init() {
+	defaultDrawFunc = DrawTerminal(os.Stdout)
+}
+
+// DrawTerminal returns a DrawFunc that draws a progress bar to an io.Writer
+// that is assumed to be a terminal (and therefore respects carriage returns).
+func DrawTerminal(w io.Writer) DrawFunc {
+	return DrawTerminalf(w, func(progress, total int64) string {
+		return fmt.Sprintf("%d/%d", progress, total)
+	})
+}
+
+// DrawTerminalf returns a DrawFunc that draws a progress bar to an io.Writer
+// that is formatted with the given formatting function.
+func DrawTerminalf(w io.Writer, f DrawTextFormatFunc) DrawFunc {
+	var maxLength int
+
+	return func(progress, total int64) error {
+		if progress == -1 || total == -1 {
+			_, err := fmt.Fprintf(w, "\n")
+			return err
+		}
+
+		// Make sure we pad it to the max length we've ever drawn so that
+		// we don't have trailing characters.
+		line := f(progress, total)
+		if len(line) < maxLength {
+			line = fmt.Sprintf(
+				"%s%s",
+				line,
+				strings.Repeat(" ", maxLength-len(line)))
+		}
+		maxLength = len(line)
+
+		_, err := fmt.Fprint(w, line+"\r")
+		return err
+	}
+}
+
+var byteUnits = []string{"B", "KB", "MB", "GB", "TB", "PB"}
+
+// DrawTextFormatBytes is a DrawTextFormatFunc that formats the progress
+// and total into human-friendly byte formats.
+func DrawTextFormatBytes(progress, total int64) string {
+	return fmt.Sprintf("%s/%s", byteUnitStr(progress), byteUnitStr(total))
+}
+
+// DrawTextFormatBar returns a DrawTextFormatFunc that draws a progress
+// bar with the given width (in characters). This can be used in conjunction
+// with another DrawTextFormatFunc to create a progress bar with bytes, for
+// example:
+//
+//     bar := DrawTextFormatBar(20)
+//     func(progress, total int64) string {
+//         return fmt.Sprintf(
+//           "%s %s",
+//           bar(progress, total),
+//           DrawTextFormatBytes(progress, total))
+//     }
+//
+func DrawTextFormatBar(width int64) DrawTextFormatFunc {
+	width -= 2
+
+	return func(progress, total int64) string {
+		current := int64((float64(progress) / float64(total)) * float64(width))
+		return fmt.Sprintf(
+			"[%s%s]",
+			strings.Repeat("=", int(current)),
+			strings.Repeat(" ", int(width - current)))
+	}
+}
+
+func byteUnitStr(n int64) string {
+	var unit string
+	size := float64(n)
+	for i := 1; i < len(byteUnits); i++ {
+		if size < 1000 {
+			unit = byteUnits[i-1]
+			break
+		}
+
+		size = size / 1000
+	}
+
+	return fmt.Sprintf("%.3g %s", size, unit)
+}

--- a/Godeps/_workspace/src/github.com/mitchellh/ioprogress/draw_test.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/ioprogress/draw_test.go
@@ -1,0 +1,72 @@
+package ioprogress
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDrawTerminal(t *testing.T) {
+	var buf bytes.Buffer
+	fn := DrawTerminal(&buf)
+	if err := fn(0, 100); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := fn(20, 100); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := fn(-1, -1); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if buf.String() != drawTerminalStr {
+		t.Fatalf("bad:\n\n%#v", buf.String())
+	}
+}
+
+func TestDrawTextFormatBar(t *testing.T) {
+	var actual, expected string
+	f := DrawTextFormatBar(10)
+
+	actual = f(5, 10)
+	expected = "[====    ]"
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+
+	actual = f(2, 10)
+	expected = "[=       ]"
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+
+	actual = f(10, 10)
+	expected = "[========]"
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
+func TestDrawTextFormatBytes(t *testing.T) {
+	cases := []struct{
+		P, T int64
+		Output string
+	}{
+		{
+			100, 500,
+			"100 B/500 B",
+		},
+		{
+			1500, 5000,
+			"1.5 KB/5 KB",
+		},
+	}
+
+	for _, tc := range cases {
+		output := DrawTextFormatBytes(tc.P, tc.T)
+		if output != tc.Output {
+			t.Fatalf("Input: %d, %d\n\n%s", tc.P, tc.T, output)
+		}
+	}
+}
+
+const drawTerminalStr = "0/100\r20/100\r\n"

--- a/Godeps/_workspace/src/github.com/mitchellh/ioprogress/reader.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/ioprogress/reader.go
@@ -1,0 +1,107 @@
+package ioprogress
+
+import (
+	"io"
+	"time"
+)
+
+// Reader is an implementation of io.Reader that draws the progress of
+// reading some data.
+type Reader struct {
+	// Reader is the underlying reader to read from
+	Reader io.Reader
+
+	// Size is the total size of the data coming out of the reader.
+	Size int64
+
+	// DrawFunc is the callback to invoke to draw the progress bar. By
+	// default, this will be DrawTerminal(os.Stdout).
+	//
+	// DrawInterval is the minimum time to wait between reads to update the
+	// progress bar.
+	DrawFunc     DrawFunc
+	DrawInterval time.Duration
+
+	progress int64
+	lastDraw time.Time
+}
+
+// Read reads from the underlying reader and invokes the DrawFunc if
+// appropriate. The DrawFunc is executed when there is data that is
+// read (progress is made) and at least DrawInterval time has passed.
+func (r *Reader) Read(p []byte) (int, error) {
+	// If we haven't drawn before, initialize the progress bar
+	if r.lastDraw.IsZero() {
+		r.initProgress()
+	}
+
+	// Read from the underlying source
+	n, err := r.Reader.Read(p)
+
+	// Always increment the progress even if there was an error
+	r.progress += int64(n)
+
+	// If we don't have any errors, then draw the progress. If we are
+	// at the end of the data, then finish the progress.
+	if err == nil {
+		// Only draw if we read data or we've never read data before (to
+		// initialize the progress bar).
+		if n > 0 {
+			r.drawProgress()
+		}
+	}
+	if err == io.EOF {
+		r.finishProgress()
+	}
+
+	return n, err
+}
+
+func (r *Reader) drawProgress() {
+	// If we've drawn before, then make sure that the draw interval
+	// has passed before we draw again.
+	interval := r.DrawInterval
+	if interval == 0 {
+		interval = time.Second
+	}
+	if !r.lastDraw.IsZero() {
+		nextDraw := r.lastDraw.Add(interval)
+		if time.Now().Before(nextDraw) {
+			return
+		}
+	}
+
+	// Draw
+	f := r.drawFunc()
+	f(r.progress, r.Size)
+
+	// Record this draw so that we don't draw again really quickly
+	r.lastDraw = time.Now()
+}
+
+func (r *Reader) finishProgress() {
+	// Only output the final draw if we drawed prior
+	if !r.lastDraw.IsZero() {
+		f := r.drawFunc()
+		f(-1, -1)
+
+		// Reset lastDraw so we don't finish again
+		var zeroDraw time.Time
+		r.lastDraw = zeroDraw
+	}
+}
+
+func (r *Reader) initProgress() {
+	var zeroDraw time.Time
+	r.lastDraw = zeroDraw
+	r.drawProgress()
+	r.lastDraw = zeroDraw
+}
+
+func (r *Reader) drawFunc() DrawFunc {
+	if r.DrawFunc == nil {
+		return defaultDrawFunc
+	}
+
+	return r.DrawFunc
+}

--- a/Godeps/_workspace/src/github.com/mitchellh/ioprogress/reader_test.go
+++ b/Godeps/_workspace/src/github.com/mitchellh/ioprogress/reader_test.go
@@ -1,0 +1,62 @@
+package ioprogress
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+	"time"
+)
+
+func TestReader(t *testing.T) {
+	testR := &testReader{
+		Data: [][]byte{
+			[]byte("ab"),
+			[]byte("cd"),
+			[]byte("ef"),
+		},
+	}
+
+	var buf bytes.Buffer
+	r := &Reader{
+		Reader:       testR,
+		Size:         testR.Size(),
+		DrawFunc:     DrawTerminal(&buf),
+		DrawInterval: time.Microsecond,
+	}
+	io.Copy(ioutil.Discard, r)
+
+	if buf.String() != drawReaderStr {
+		t.Fatalf("bad:\n\n%#v", buf.String())
+	}
+}
+
+const drawReaderStr = "0/6\r2/6\r4/6\r6/6\r\n"
+
+// testReader is a test structure to help with testing the Reader by
+// returning fixed slices of data.
+type testReader struct {
+	Data [][]byte
+	i    int
+}
+
+func (r *testReader) Read(p []byte) (int, error) {
+	// This is just so that our interval will fire properly
+	time.Sleep(5 * time.Microsecond)
+
+	if r.i == len(r.Data) {
+		return 0, io.EOF
+	}
+
+	copy(p, r.Data[r.i])
+	r.i += 1
+	return len(r.Data[r.i-1]), nil
+}
+
+func (r *testReader) Size() (n int64) {
+	for _, d := range r.Data {
+		n += int64(len(d))
+	}
+
+	return
+}


### PR DESCRIPTION
This introduces ProgressReader, a io.Reader proxy that keeps track of
the bytes read and fires off a callback with the current state.

Fixes #208

---

There are lots of different ways of doing this. I don't know if there is any precedent for writing to stdout yet, but this seems okay for now.
