### PR TITLE
tar: fixing extracting files that are dirs 

### DIFF
--- a/pkg/tar/tar.go
+++ b/pkg/tar/tar.go
@@ -47,6 +47,13 @@ func ExtractTar(tr *tar.Reader, dir string) error {
 				if err := os.MkdirAll(p, fi.Mode()); err != nil {
 					return err
 				}
+				dir, err := os.Open(p)
+				if err != nil {
+					return err
+				}
+				if err := dir.Chmod(fi.Mode()); err != nil {
+					return err
+				}
 			case typ == tar.TypeLink:
 				dest := filepath.Join(dir, hdr.Linkname)
 				if !strings.HasPrefix(dest, dir) {

--- a/pkg/tar/tar_test.go
+++ b/pkg/tar/tar_test.go
@@ -104,6 +104,13 @@ func TestExtractTarFolders(t *testing.T) {
 			},
 		},
 		{
+			header: &tar.Header{
+				Name:     "deep/folder/",
+				Typeflag: tar.TypeDir,
+				Mode:     int64(0747),
+			},
+		},
+		{
 			contents: "bar",
 			header: &tar.Header{
 				Name: "deep/folder/bar.txt",
@@ -116,7 +123,6 @@ func TestExtractTarFolders(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-
 	defer os.Remove(testTarPath)
 	containerTar, err := os.Open(testTarPath)
 	if err != nil {
@@ -143,4 +149,9 @@ func TestExtractTarFolders(t *testing.T) {
 	if len(matches) != 2 {
 		t.Errorf("unexpected number of files found: %d, wanted 2", len(matches))
 	}
+	dirInfo, err := os.Lstat(filepath.Join(tmpdir, "deep/folder"))
+	if dirInfo.Mode().Perm() != os.FileMode(0747) {
+		t.Errorf("unexpected dir mode: %s", dirInfo.Mode())
+	}
+
 }


### PR DESCRIPTION
Fix https://github.com/coreos/rocket/issues/250

The dirs are created using [0755](https://github.com/mcuadros/rocket/compare/coreos:master...master#diff-6b4b95c3fb2a650ac8b9a0c5eabdb8b3R13) as default mode, following the same behaviour from the BSD tar.
