### PR TITLE
Fix archive validation.

### DIFF
--- a/app-container/aci/layout.go
+++ b/app-container/aci/layout.go
@@ -97,20 +97,22 @@ Tar:
 		default:
 			return err
 		}
-		switch hdr.Name {
+		name := filepath.Clean(hdr.Name)
+		switch name {
+		case ".":
 		case "app":
 			_, err := io.Copy(&im, tr)
 			if err != nil {
 				return err
 			}
 			imOK = true
-		case "rootfs/":
+		case "rootfs":
 			if !hdr.FileInfo().IsDir() {
 				return fmt.Errorf("rootfs is not a directory")
 			}
 			rfsOK = true
 		default:
-			flist = append(flist, hdr.Name)
+			flist = append(flist, name)
 		}
 	}
 	return validate(imOK, &im, rfsOK, flist)


### PR DESCRIPTION
The tar Header.Name (for example with gnu tar) can start with ./ (for example ./app and ./rootfs/).
Use filepath.Clean and use the cleaned up name. This also makes the logic similar to
ValidateLayout().
