### PR TITLE
Better gitignore rule for vim tmp files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ gopath/
 stage0/stage1_init/
 stage0/stage1_rootfs/
 stage1/cache/
-*/*.swp
+*.sw[ponm]


### PR DESCRIPTION
- Old rule didn't work for top level dir
- New rule includes not-first vim tmp files

Signed-off-by: Daniel Farrell dfarrell@redhat.com
