### PR TITLE
cas: clean blockTransform, panic intentionally

### DIFF
--- a/cas/utils.go
+++ b/cas/utils.go
@@ -4,6 +4,7 @@ import (
 	"compress/bzip2"
 	"compress/gzip"
 	"errors"
+	"fmt"
 	"io"
 	"net/url"
 	"strings"
@@ -11,15 +12,21 @@ import (
 	"github.com/appc/spec/aci"
 )
 
-// copy the default of git which is a two byte prefix. We will likely want to
-// add re-sharding later.
+// blockTransform creates a path slice from the given string to use as a
+// directory prefix. The string must be in hash format:
+//    "sha256-abcdefgh"... -> []{"sha256", "ab"}
+// Right now it just copies the default of git which is a two byte prefix. We
+// will likely want to add re-sharding later.
 func blockTransform(s string) []string {
 	// TODO(philips): use spec/types.Hash after export typ field
 	parts := strings.SplitN(s, "-", 2)
-	pathSlice := make([]string, 2)
-	pathSlice[0] = parts[0]
-	pathSlice[1] = parts[1][0:2]
-	return pathSlice
+	if len(parts) != 2 {
+		panic(fmt.Errorf("blockTransform should never receive non-hash, got %v", s))
+	}
+	return []string{
+		parts[0],
+		parts[1][0:2],
+	}
 }
 
 func parseAlways(s string) *url.URL {


### PR DESCRIPTION
There was a bug in diskv (https://github.com/peterbourgon/diskv/pull/20) which
meant that the blockTransform function could be passed an empty string. In our
case this just paniced after trying to split + access parts of the resulting
empty slice.

Panicking is arguably correct behaviour (if we ever get something that's not a
hash it's likely a bug in our code), but let's be more intentional about it.
