### PR TITLE
test: disable travis sudo ability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: go
 
+sudo: false
+
 go:
  - 1.3
 


### PR DESCRIPTION
Makes test starting a lot quicker, and sudo shouldn't be necessary

apparently all the cool kids are doing it.
