### PR TITLE
pkg/lock: refactor DirLock to facilitate discrete opens

### DIFF
--- a/pkg/lock/dir_test.go
+++ b/pkg/lock/dir_test.go
@@ -14,7 +14,7 @@ func TestNewLock(t *testing.T) {
 	defer os.Remove(f.Name())
 	f.Close()
 
-	l, err := newLock(f.Name())
+	l, err := NewLock(f.Name())
 	if err == nil || l != nil {
 		t.Fatal("expected error creating lock on file")
 	}
@@ -25,9 +25,9 @@ func TestNewLock(t *testing.T) {
 	}
 	defer os.Remove(d)
 
-	l, err = newLock(d)
+	l, err = NewLock(d)
 	if err != nil {
-		t.Fatalf("error creating newLock: %v", err)
+		t.Fatalf("error creating NewLock: %v", err)
 	}
 
 	err = l.Close()
@@ -39,7 +39,7 @@ func TestNewLock(t *testing.T) {
 		t.Fatalf("error removing tmpdir: %v", err)
 	}
 
-	l, err = newLock(d)
+	l, err = NewLock(d)
 	if err == nil {
 		t.Fatalf("expected error creating lock on nonexistent path")
 	}
@@ -56,6 +56,12 @@ func TestExclusiveLock(t *testing.T) {
 	l, err := ExclusiveLock(dir)
 	if err != nil {
 		t.Fatalf("error creating lock: %v", err)
+	}
+
+	// reacquire the exclusive lock using the receiver interface
+	err = l.TryExclusiveLock()
+	if err != nil {
+		t.Fatalf("error reacquiring exclusive lock: %v", err)
 	}
 
 	// Now try another exclusive lock, should fail
@@ -88,6 +94,11 @@ func TestSharedLock(t *testing.T) {
 	l1, err := SharedLock(dir)
 	if err != nil {
 		t.Fatalf("error creating new shared lock: %v", err)
+	}
+
+	err = l1.TrySharedLock()
+	if err != nil {
+		t.Fatalf("error reacquiring shared lock: %v", err)
 	}
 
 	// Subsequent shared locks should succeed


### PR DESCRIPTION
 This also restores atomic lock conversions
- Discard DirLock interface
- Convert private lock struct into public DirLock
- Convert private newLock function to public NewLock
- Introduce receiver-based analogs of all acquisition functions
- Convert existing open+acquire functions to use the public receiver-based
  acquistion functions.
