### PR TITLE
stage1/init/common: GenerateMounts refactoring

### DIFF
--- a/stage1/init/common/app.go
+++ b/stage1/init/common/app.go
@@ -127,8 +127,8 @@ func prepareApp(p *stage1commontypes.Pod, ra *schema.RuntimeApp) (*preparedApp, 
 	}
 
 	// Determine mounts
-	cfd := ConvertedFromDocker(p.Images[ra.Name.String()])
-	pa.mounts, err = GenerateMounts(ra, p.Manifest.Volumes, cfd)
+	runtimeMounts := NewRuntimeMounts(ra, p)
+	pa.mounts, err = runtimeMounts.Mounts()
 	if err != nil {
 		return nil, errwrap.Wrap(errors.New("unable to compute mounts"), err)
 	}

--- a/stage1/init/common/mount.go
+++ b/stage1/init/common/mount.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rkt/rkt/pkg/fileutil"
 	"github.com/rkt/rkt/pkg/fs"
 	"github.com/rkt/rkt/pkg/user"
+	stage1types "github.com/rkt/rkt/stage1/common/types"
 
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
@@ -68,131 +69,260 @@ func (m *Mount) Source(podRoot string) string {
 	case "empty":
 		return filepath.Join(common.SharedVolumesPath(podRoot), m.Volume.Name.String())
 	}
-	return "" // We validate in GenerateMounts that it's valid
+	return "" // We validate in RuntimeMounts that it's valid
 }
 
-// GenerateMounts maps MountPoint paths to volumes, returning a list of mounts,
-// each with a parameter indicating if it's an implicit empty volume from a
-// Docker image.
-func GenerateMounts(ra *schema.RuntimeApp, podVolumes []types.Volume, convertedFromDocker bool) ([]Mount, error) {
-	app := ra.App
+type (
+	// volumesMap is a mapping of volume name to volume details.
+	volumesMap map[types.ACName]types.Volume
 
-	var genMnts []Mount
+	// mountsMap is a mapping of mount point name to mount point details.
+	mountsMap map[types.ACName]types.MountPoint
+)
 
-	vols := make(map[types.ACName]types.Volume)
-	for _, v := range podVolumes {
-		vols[v.Name] = v
+// rtmState is a state of the POD manifest traverse though the volumes
+// configuration of the runtime application. It holds the mappings of
+// of volumes and mounts for fast access.
+type rtmState struct {
+	// Configuration of the runtime mounts.
+	rtm *RuntimeMounts
+
+	// processed defines a set of processed mount points, so we don't
+	// have to walk though them multiple times.
+	processed map[string]struct{}
+
+	// The mappings of the POD volumes and the application mount points
+	// for the fast access.
+	volumes volumesMap
+	mounts  mountsMap
+}
+
+// newRtmState returns a new instance of the runtime-mounts state.
+func newRtmState(rtm *RuntimeMounts) *rtmState {
+	return &rtmState{rtm: rtm, processed: make(map[string]struct{})}
+}
+
+// Mark the specified path as processed.
+func (s *rtmState) process(path string) {
+	s.processed[path] = struct{}{}
+}
+
+// isProcessed returns true when the path have been already processed
+// and false otherwise.
+func (s *rtmState) isProcessed(path string) bool {
+	_, ok := s.processed[path]
+	return ok
+}
+
+// mountPointOf returns a mount point of the corresponding volume with
+// an indicator of mount point existence.
+//
+// This method used for a lazy evaluation of the mapping of mount-point
+// names to the mount-point details.
+func (s *rtmState) mountPointOf(vol types.ACName) (types.MountPoint, bool) {
+	if s.mounts == nil {
+		app := s.rtm.Application.App
+		s.mounts = make(mountsMap, len(app.MountPoints))
+
+		for _, mp := range app.MountPoints {
+			s.mounts[mp.Name] = mp
+		}
 	}
 
-	// RuntimeApps have mounts, whereas Apps have mountPoints. mountPoints are partially for
-	// Docker compat; since apps can declare mountpoints. However, if we just run with rkt run,
-	// then we'll only have a Mount and no corresponding MountPoint.
-	// Furthermore, Mounts can have embedded volumes in the case of the CRI.
-	// So, we generate a pile of Mounts and their corresponding Volume
+	mp, ok := s.mounts[vol]
+	return mp, ok
+}
 
-	// Map of hostpath -> Mount
-	mnts := make(map[string]schema.Mount)
+// volumeOf returns a volume details of the POD with an indicator of
+// volume existence.
+func (s *rtmState) volumeOf(vol types.ACName) (types.Volume, bool) {
+	if s.volumes == nil {
+		s.volumes = make(volumesMap, len(s.rtm.Volumes))
+		for _, v := range s.rtm.Volumes {
+			s.volumes[v.Name] = v
+		}
+	}
 
+	v, ok := s.volumes[vol]
+	return v, ok
+}
+
+// RuntimeMounts represents a mount points generator of the runtime
+// application.
+type RuntimeMounts struct {
+	// Application is the runtime application to generate mount points.
+	Application *schema.RuntimeApp
+
+	// Volumes specifies a list of volumes of the application.
+	Volumes []types.Volume
+
+	// DockerImplicit indicates if the resulting mount points should be
+	// marked as implicit empty volumes from a Docker image.
+	DockerImplicit bool
+}
+
+// NewRuntimeMounts creates a new instance of the RuntimeMounts with a
+// attributes retrieved from the given POD configuration.
+func NewRuntimeMounts(ra *schema.RuntimeApp, pod *stage1types.Pod) *RuntimeMounts {
+	return &RuntimeMounts{
+		Application: ra,
+		Volumes:     pod.Manifest.Volumes,
+		DockerImplicit: ConvertedFromDocker(
+			pod.Images[ra.Name.String()],
+		),
+	}
+}
+
+// emptyVolume returns a new instance of the empty volume with a unique
+// name and default configuration.
+func (rtm *RuntimeMounts) emptyVolume(mpoint *types.MountPoint) types.Volume {
+	defaultMode := "0755"
+	uniqName := rtm.Application.Name + "-" + mpoint.Name
+
+	return types.Volume{
+		Name: uniqName,
+		Kind: "empty",
+		Mode: &defaultMode,
+		UID:  new(int),
+		GID:  new(int),
+	}
+}
+
+// traverseMounts builds a mapping of the mounts of the runtime application
+// to the volumes declared in a POD manifest. For each successfully created
+// mapping function executes a specified call-back function for further
+// processing.
+//
+// An error returns, when runtime application declares a mount for non-existing
+// volume (i.e. POD manifest is missing the respective volume declaration).
+func (rtm *RuntimeMounts) traverseMounts(s *rtmState, f func(m Mount) error) error {
 	// Check runtimeApp's Mounts
-	for _, m := range ra.Mounts {
-		mnts[m.Path] = m
-
+	for _, m := range rtm.Application.Mounts {
 		vol := m.AppVolume // Mounts can supply a volume
 		if vol == nil {
-			vv, ok := vols[m.Volume]
+			vv, ok := s.volumeOf(m.Volume)
 			if !ok {
-				return nil, fmt.Errorf("could not find volume %s", m.Volume)
+				return fmt.Errorf("could not find volume %s", m.Volume)
 			}
 			vol = &vv
 		}
 
 		// Find a corresponding MountPoint, which is optional
-		ro := false
-		for _, mp := range ra.App.MountPoints {
-			if mp.Name == m.Volume {
-				ro = mp.ReadOnly
-				break
-			}
-		}
+		mpoint, _ := s.mountPointOf(m.Volume)
+		ro := mpoint.ReadOnly
+
 		if vol.ReadOnly != nil {
 			ro = *vol.ReadOnly
 		}
 
 		switch vol.Kind {
-		case "host":
-		case "empty":
+		case "host", "empty":
 		default:
-			return nil, fmt.Errorf("Volume %s has invalid kind %s", vol.Name, vol.Kind)
+			const text = "Volume %s has invalid kind %s"
+			return fmt.Errorf(text, vol.Name, vol.Kind)
 		}
-		genMnts = append(genMnts,
-			Mount{
-				Mount:          m,
-				DockerImplicit: false,
-				ReadOnly:       ro,
-				Volume:         *vol,
-			})
+
+		mount := Mount{m, *vol, false, ro}
+		if err := f(mount); err != nil {
+			return err
+		}
+
+		s.process(m.Path)
 	}
+
+	return nil
+}
+
+// traverseMountPoints builds a mapping of the mount points of runtime
+// application that does not declare a corresponding mount in a manifest.
+//
+// In order to preserve compatibility with Docker images, applications are
+// allowed to declare mounts without corresponsind mount points, therefore,
+// it is required to generate an empty volume for each unmapped mount.
+//
+// For each mount successfully created mapping function executes a specified
+// call-back function for further processing.
+func (rtm *RuntimeMounts) traverseMountPoints(s *rtmState, f func(Mount) error) error {
+	var mount Mount
 
 	// Now, match up MountPoints with Mounts or Volumes
 	// If there's no Mount and no Volume, generate an empty volume
-	for _, mp := range app.MountPoints {
+	for _, mp := range rtm.Application.App.MountPoints {
 		// there's already a Mount for this MountPoint, stop
-		if _, ok := mnts[mp.Path]; ok {
+		if s.isProcessed(mp.Path) {
 			continue
 		}
 
 		// No Mount, try to match based on volume name
-		vol, ok := vols[mp.Name]
+		vol, ok := s.volumeOf(mp.Name)
 		// there is no volume for this mount point, creating an "empty" volume
 		// implicitly
 		if !ok {
-			defaultMode := "0755"
-			defaultUID := 0
-			defaultGID := 0
-			uniqName := ra.Name + "-" + mp.Name
-			emptyVol := types.Volume{
-				Name: uniqName,
-				Kind: "empty",
-				Mode: &defaultMode,
-				UID:  &defaultUID,
-				GID:  &defaultGID,
-			}
-
 			log.Printf("warning: no volume specified for mount point %q, implicitly creating an \"empty\" volume. This volume will be removed when the pod is garbage-collected.", mp.Name)
-			if convertedFromDocker {
+
+			if rtm.DockerImplicit {
 				log.Printf("Docker converted image, initializing implicit volume with data contained at the mount point %q.", mp.Name)
 			}
 
-			vols[uniqName] = emptyVol
-			genMnts = append(genMnts,
-				Mount{
-					Mount: schema.Mount{
-						Volume: uniqName,
-						Path:   mp.Path,
-					},
-					Volume:         emptyVol,
-					ReadOnly:       mp.ReadOnly,
-					DockerImplicit: convertedFromDocker,
-				})
+			emptyVol := rtm.emptyVolume(&mp)
+			s.volumes[emptyVol.Name] = emptyVol
+
+			acm := schema.Mount{Volume: emptyVol.Name, Path: mp.Path}
+			mount = Mount{acm, emptyVol, rtm.DockerImplicit, mp.ReadOnly}
 		} else {
 			ro := mp.ReadOnly
 			if vol.ReadOnly != nil {
 				ro = *vol.ReadOnly
 			}
-			genMnts = append(genMnts,
-				Mount{
-					Mount: schema.Mount{
-						Volume: vol.Name,
-						Path:   mp.Path,
-					},
-					Volume:         vol,
-					ReadOnly:       ro,
-					DockerImplicit: false,
-				})
+
+			acm := schema.Mount{Volume: vol.Name, Path: mp.Path}
+			mount = Mount{acm, vol, false, ro}
+		}
+
+		if err := f(mount); err != nil {
+			return err
 		}
 	}
 
-	return genMnts, nil
+	return nil
+}
+
+// Mounts maps mount-point paths to volumes, returning a list of mounts.
+func (rtm *RuntimeMounts) Mounts() ([]Mount, error) {
+	var mountPoints []Mount
+
+	err := rtm.MountsFunc(func(m Mount) error {
+		mountPoints = append(mountPoints, m)
+		return nil
+	})
+
+	// Return a nil slice in case of the error happened during the
+	// iteration over the mount points of the runtime application.
+	if err != nil {
+		mountPoints = nil
+	}
+
+	return mountPoints, err
+}
+
+// MountsFunc maps mount-point path to volumes and applies a given
+// function to it.
+func (rtm *RuntimeMounts) MountsFunc(f func(Mount) error) error {
+	// RuntimeApps have mounts, whereas Apps have mountPoints; mountPoints
+	// are partially for Docker compat; since apps can declare mountpoints.
+	//
+	// However, if we just run with rkt run, then we'll only have a Mount
+	// and no corresponding MountPoint. Furthermore, Mounts can have embedded
+	// volumes in the case of the CRI.
+	//
+	// So, we generate a pile of Mounts and their corresponding Volume
+
+	st := newRtmState(rtm)
+	if err := rtm.traverseMounts(st, f); err != nil {
+		return err
+	}
+
+	return rtm.traverseMountPoints(st, f)
 }
 
 // PrepareMountpoints creates and sets permissions for empty volumes.

--- a/stage1/init/common/mount_test.go
+++ b/stage1/init/common/mount_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/appc/spec/schema/types"
 )
 
-func TestGenerateMounts(t *testing.T) {
+func TestRuntimeMounts(t *testing.T) {
 	tests := []struct {
 		ra         *schema.RuntimeApp
 		vols       []types.Volume
@@ -178,7 +178,13 @@ func TestGenerateMounts(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		result, err := GenerateMounts(tt.ra, tt.vols, tt.fromDocker)
+		runtimeMounts := RuntimeMounts{
+			Application:    tt.ra,
+			Volumes:        tt.vols,
+			DockerImplicit: tt.fromDocker,
+		}
+
+		result, err := runtimeMounts.Mounts()
 		if (err != nil) != tt.hasErr {
 			t.Errorf("test %d expected error status %t, didn't get it", i, tt.hasErr)
 		}


### PR DESCRIPTION
This patch provides a refactoring of the GenerateMounts function from
the "stage1/init/common" package in order to reduce the amount of the
loops over the mount points.

The implementation replaces the old function "GenerateMounts" and ships
a new type called "RuntimeMounts" that provides "Mounts" to reproduce
previous behavior and a new function "MountsFunc" that calls a
user-defined function for each mount point.

closes #2380