### PR TITLE
stage1: include <sys/sysmacros.h> for makedev function

### DIFF
--- a/stage1/prepare-app/prepare-app.c
+++ b/stage1/prepare-app/prepare-app.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <fcntl.h>


### PR DESCRIPTION
In glibc, inclusion of <sys/sysmacros.h> by <sys/types.h> has
been deprecated, so files that use makedev need to explicitly
include <sys/sysmacros.h>.

See:
https://sourceware.org/git/?p=glibc.git;a=commit;h=dbab6577c6684c62bd2521c1c29dc25c3cac966f