### PR TITLE
fetch: use proper appc os/arch labels

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -485,4 +486,31 @@ func GetExitStatus(err error) (int, error) {
 		}
 	}
 	return -1, err
+}
+
+// reference to GOARM, needs to be globally, if in GetArch() function it resolves to zero
+//go:linkname goarm runtime.goarm
+var goarm uint8
+
+// GetArch returns the current architecture. It returns runtime.GOARCH if not on a arm device
+// and armv6l, armv7l, arm64 otherwise
+func GetArch() string {
+	arch := runtime.GOARCH
+	switch arch {
+	case "arm":
+		{
+			os := GetOS()
+			_, arch, _ = types.ToAppcOSArch(os, "arm", strconv.Itoa(int(goarm)))
+		}
+	case "arm64":
+		{
+			arch = "aarch64"
+		}
+	}
+	return arch
+}
+
+// GetOS returns the current operating system (linux, windows etc...)
+func GetOS() string {
+	return runtime.GOOS
 }

--- a/common/common.go
+++ b/common/common.go
@@ -496,17 +496,11 @@ var goarm uint8
 // and armv6l, armv7l, arm64 otherwise
 func GetArch() string {
 	arch := runtime.GOARCH
-	switch arch {
-	case "arm":
-		{
-			os := GetOS()
-			_, arch, _ = types.ToAppcOSArch(os, "arm", strconv.Itoa(int(goarm)))
-		}
-	case "arm64":
-		{
-			arch = "aarch64"
-		}
+	flavor := ""
+	if arch == "arm" {
+		flavor = strconv.Itoa(int(goarm))
 	}
+	_, arch, _ = types.ToAppcOSArch(GetOS(), arch, flavor)
 	return arch
 }
 

--- a/rkt/fetch.go
+++ b/rkt/fetch.go
@@ -15,9 +15,8 @@
 package main
 
 import (
-	"runtime"
-
 	"github.com/appc/spec/schema/types"
+	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/apps"
 	"github.com/coreos/rkt/rkt/image"
 	"github.com/coreos/rkt/store/imagestore"
@@ -26,13 +25,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	defaultOS   = runtime.GOOS
-	defaultArch = runtime.GOARCH
-)
-
 var (
-	cmdFetch = &cobra.Command{
+	defaultOS   = common.GetOS()
+	defaultArch = common.GetArch()
+	cmdFetch    = &cobra.Command{
 		Use:   "fetch IMAGE_URL...",
 		Short: "Fetch image(s) and store them in the local store",
 		Long: `Locates and downloads remote ACIs and their attached signatures.

--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"runtime"
 
 	"github.com/coreos/rkt/common"
 	"github.com/coreos/rkt/common/apps"
@@ -287,10 +286,10 @@ func (f *Fetcher) fetchSingleImageByPath(path string, a *asc) (string, error) {
 func (db *distBundle) setAppDefaults() error {
 	app := db.dist.(*dist.Appc).App()
 	if _, ok := app.Labels["arch"]; !ok {
-		app.Labels["arch"] = runtime.GOARCH
+		app.Labels["arch"] = common.GetArch()
 	}
 	if _, ok := app.Labels["os"]; !ok {
-		app.Labels["os"] = runtime.GOOS
+		app.Labels["os"] = common.GetOS()
 	}
 	if err := types.IsValidOSArch(app.Labels, stage0.ValidOSArch); err != nil {
 		return errwrap.Wrap(fmt.Errorf("invalid Appc distribution %q", db.image), err)


### PR DESCRIPTION
added function GetArch() to common/common.go which replaces runtime.GOARCH-calls in fetch related code. GetArch() returns the architecture of the current system, and especially returns either armv6l, armv7l or aarch64 if on arm devices (GOARCH is always arm). This leads to working rkt fetch on arm devices.