### PR TITLE
kvm/qemu: add extra kernel parameters

### DIFF
--- a/Documentation/running-kvm-stage1.md
+++ b/Documentation/running-kvm-stage1.md
@@ -78,3 +78,22 @@ This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.25.0
 [rkt-arch-stage1]: devel/architecture.md#stage-1
 [rkt-run]: subcommands/run.md#use-a-custom-stage-1
 [stage1-implementers-guide]: devel/stage1-implementors-guide.md
+
+## Additional parameters
+
+The KVM stage1 has some hypervisor specific parameters that can change the execution environment.
+
+### Extra kernel command line parameters
+
+Additional [Linux kernel's command line parameters](https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html) can be passed via the environment variable `RKT_HYPERVISOR_EXTRA_KERNEL_PARAMS`:
+
+```
+sudo RKT_HYPERVISOR_EXTRA_KERNEL_PARAMS="systemd.unified_cgroup_hierarchy=true max_loop=12 possible_cpus=1" \
+      rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.25.0 \
+      ...
+```
+
+The three command line parameters above are just examples and they are documented respectively in:
+- [systemd's kernel command line parameters](https://www.freedesktop.org/software/systemd/man/kernel-command-line.html)
+- [Linux' parameters](https://github.com/torvalds/linux/blob/master/Documentation/admin-guide/kernel-parameters.txt)
+- [Linux' CPU hotplug](https://github.com/torvalds/linux/blob/master/Documentation/core-api/cpu_hotplug.rst)

--- a/stage1/init/kvm/hypervisor/hypervisor.go
+++ b/stage1/init/kvm/hypervisor/hypervisor.go
@@ -14,6 +14,8 @@
 
 package hypervisor
 
+import "os"
+
 // KvmHypervisor structure describes KVM hypervisor binary and its parameters
 type KvmHypervisor struct {
 	Bin          string
@@ -43,5 +45,10 @@ func (hv *KvmHypervisor) InitKernelParams(isDebug bool) {
 			"quiet=vga",
 			"quiet systemd.log_level=emerg",
 		}...)
+	}
+
+	customKernelParams := os.Getenv("RKT_HYPERVISOR_EXTRA_KERNEL_PARAMS")
+	if customKernelParams != "" {
+		hv.KernelParams = append(hv.KernelParams, customKernelParams)
 	}
 }


### PR DESCRIPTION
For testing purpose, I need to add custom kernel parameters in the VM.

Implemented in this way:

```
sudo RKT_HYPERVISOR_EXTRA_KERNEL_PARAMS="foo1=bar foo2=bar" \
  ./build-rkt-1.21.0+git/target/bin/rkt run \
  --stage1-path=$PWD/build-rkt-1.21.0+git/target/bin/stage1-kvm.aci \
  --insecure-options=image --interactive \
  docker://busybox --cpu 1 --exec sh -- -c \
  'cat /proc/cmdline'

noapic noacpi pci=conf1 reboot=k panic=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 console=ttyS0 i8042.noaux=1 rw rootflags=trans=virtio,version=9p2000.L,cache=mmap rootfstype=9p systemd.default_standard_error=journal+console systemd.default_standard_output=journal+console systemd.machine_id=3a2af63d415946778491bda1cb828c57 console=hvc0 init=/usr/lib/systemd/systemd no_timer_check noreplace-smp tsc=reliable systemd.show_status=false systemd.log_target=null rd.udev.log-priority=3 quiet=vga quiet systemd.log_level=emerg foo1=bar foo2=bar
```

-----

We'll need this for https://github.com/kinvolk/stage1-builder
/cc @schu 