### PR TITLE
docs: add AWS ECR link to examples of Docker registries

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -207,7 +207,7 @@ A short list of popular Docker registries is given below.
 The `credentials` field holds the necessary data to authenticate against the Docker registry.
 This field must be specified and cannot be empty.
 
-Currently, Docker registries only support basic HTTP authentication, so `credentials` has two subfields - `user` and `password`. These fields must be specified and cannot be empty. For registries like [AWS ECR](https://aws.amazon.com/ecr/) tools may be used to obtain credentials and registry endpoints. For example, use `aws ecr get-login` to fetch login credentials when using AWS.
+Currently, Docker registries only support basic HTTP authentication, so `credentials` has two subfields - `user` and `password`. These fields must be specified and cannot be empty. For registries like [AWS ECR](https://aws.amazon.com/ecr/) tools may be used to obtain credentials and registry endpoints. For example, use `aws ecr get-login` to fetch login credentials when using AWS. Please keep in mind that when using ECR the credentials will expire and will need to be refreshed.
 
 Some popular Docker registries:
 

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -215,6 +215,7 @@ Some popular Docker registries:
 * registry-1.docker.io (Assumed as the default when no specific registry is named on the rkt command line, as in `docker:///redis`.)
 * quay.io
 * gcr.io
+* `<aws_account_id>`.dkr.ecr.`<region>`.amazonaws.com (AWS ECR)
 
 Example `dockerAuth` configuration:
 

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -207,8 +207,7 @@ A short list of popular Docker registries is given below.
 The `credentials` field holds the necessary data to authenticate against the Docker registry.
 This field must be specified and cannot be empty.
 
-Currently, Docker registries only support basic HTTP authentication, so `credentials` has two subfields - `user` and `password`.
-These fields must be specified and cannot be empty.
+Currently, Docker registries only support basic HTTP authentication, so `credentials` has two subfields - `user` and `password`. These fields must be specified and cannot be empty. For registries like [AWS ECR](https://aws.amazon.com/ecr/) tools may be used to obtain credentials and registry endpoints. For example, use `aws ecr get-login` to fetch login credentials when using AWS.
 
 Some popular Docker registries:
 


### PR DESCRIPTION
Issue: https://github.com/coreos/rkt/issues/3157
Example credit goes to @sjansen

It seems that a generic solution is already documented in [configuration](https://github.com/coreos/rkt/blob/master/Documentation/configuration.md#description-and-examples-1) options. That said, I had the same experience as @thattommyhall and concluded that Amazon's ECR was not working with rkt.

This PR purposes adding ECR as an example Docker registry to help others in the future find the solution.

cc @jonboulle
