### PR TITLE
rkt list|status: app state info (i.e. exit codes) in --format=json

### DIFF
--- a/api/v1/json.go
+++ b/api/v1/json.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rkt
+package v1
 
 import "github.com/rkt/rkt/networking/netinfo"
 

--- a/lib/app.go
+++ b/lib/app.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/appc/spec/schema"
+	"github.com/rkt/rkt/api/v1"
 	"github.com/rkt/rkt/common"
 	pkgPod "github.com/rkt/rkt/pkg/pod"
 )
@@ -30,11 +31,11 @@ import (
 // * App.StartedAt
 // * App.FinishedAt
 // * App.ExitCode
-type appStateFunc func(*App, *pkgPod.Pod) error
+type appStateFunc func(*v1.App, *pkgPod.Pod) error
 
 // AppsForPod returns the apps of the pod with the given uuid in the given data directory.
 // If appName is non-empty, then only the app with the given name will be returned.
-func AppsForPod(uuid, dataDir string, appName string) ([]*App, error) {
+func AppsForPod(uuid, dataDir string, appName string) ([]*v1.App, error) {
 	p, err := pkgPod.PodFromUUIDString(dataDir, uuid)
 	if err != nil {
 		return nil, err
@@ -44,13 +45,13 @@ func AppsForPod(uuid, dataDir string, appName string) ([]*App, error) {
 	return appsForPod(p, appName, appStateInMutablePod)
 }
 
-func appsForPod(p *pkgPod.Pod, appName string, appState appStateFunc) ([]*App, error) {
+func appsForPod(p *pkgPod.Pod, appName string, appState appStateFunc) ([]*v1.App, error) {
 	_, podManifest, err := p.PodManifest()
 	if err != nil {
 		return nil, err
 	}
 
-	var apps []*App
+	var apps []*v1.App
 	for _, ra := range podManifest.Apps {
 		if appName != "" && appName != ra.Name.String() {
 			continue
@@ -69,8 +70,8 @@ func appsForPod(p *pkgPod.Pod, appName string, appState appStateFunc) ([]*App, e
 }
 
 // newApp constructs the App object with the runtime app and pod manifest.
-func newApp(ra *schema.RuntimeApp, podManifest *schema.PodManifest, pod *pkgPod.Pod, appState appStateFunc) (*App, error) {
-	app := &App{
+func newApp(ra *schema.RuntimeApp, podManifest *schema.PodManifest, pod *pkgPod.Pod, appState appStateFunc) (*v1.App, error) {
+	app := &v1.App{
 		Name:            ra.Name.String(),
 		ImageID:         ra.Image.ID.String(),
 		UserAnnotations: ra.App.UserAnnotations,
@@ -78,7 +79,7 @@ func newApp(ra *schema.RuntimeApp, podManifest *schema.PodManifest, pod *pkgPod.
 	}
 
 	for _, mnt := range ra.Mounts {
-		app.Mounts = append(app.Mounts, &Mount{
+		app.Mounts = append(app.Mounts, &v1.Mount{
 			Name:          mnt.Volume.String(),
 			ContainerPath: mnt.Path,
 			HostPath:      mnt.AppVolume.Source,
@@ -94,15 +95,15 @@ func newApp(ra *schema.RuntimeApp, podManifest *schema.PodManifest, pod *pkgPod.
 	return app, nil
 }
 
-func appStateInMutablePod(app *App, pod *pkgPod.Pod) error {
-	app.State = AppStateUnknown
+func appStateInMutablePod(app *v1.App, pod *pkgPod.Pod) error {
+	app.State = v1.AppStateUnknown
 
 	defer func() {
 		if pod.IsAfterRun() {
 			// If the pod is hard killed, set the app to 'exited' state.
 			// Other than this case, status file is guaranteed to be written.
-			if app.State != AppStateExited {
-				app.State = AppStateExited
+			if app.State != v1.AppStateExited {
+				app.State = v1.AppStateExited
 				t, err := pod.GCMarkedTime()
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Cannot get GC marked time: %v", err)
@@ -124,7 +125,7 @@ func appStateInMutablePod(app *App, pod *pkgPod.Pod) error {
 		return nil
 	}
 
-	app.State = AppStateCreated
+	app.State = v1.AppStateCreated
 	createdAt := fi.ModTime().UnixNano()
 	app.CreatedAt = &createdAt
 
@@ -137,7 +138,7 @@ func appStateInMutablePod(app *App, pod *pkgPod.Pod) error {
 		return nil
 	}
 
-	app.State = AppStateRunning
+	app.State = v1.AppStateRunning
 	startedAt := fi.ModTime().UnixNano()
 	app.StartedAt = &startedAt
 
@@ -151,7 +152,7 @@ func appStateInMutablePod(app *App, pod *pkgPod.Pod) error {
 		return nil
 	}
 
-	app.State = AppStateExited
+	app.State = v1.AppStateExited
 	finishedAt := fi.ModTime().UnixNano()
 	app.FinishedAt = &finishedAt
 
@@ -166,7 +167,7 @@ func appStateInMutablePod(app *App, pod *pkgPod.Pod) error {
 }
 
 // appStateInImmutablePod infers most App state from the Pod itself, since all apps are created and destroyed with the Pod
-func appStateInImmutablePod(app *App, pod *pkgPod.Pod) error {
+func appStateInImmutablePod(app *v1.App, pod *pkgPod.Pod) error {
 	app.State = appStateFromPod(pod)
 
 	t, err := pod.CreationTime()
@@ -179,7 +180,7 @@ func appStateInImmutablePod(app *App, pod *pkgPod.Pod) error {
 	code, err := pod.AppExitCode(app.Name)
 	if err == nil {
 		// there is an exit code, it is definitely Exited
-		app.State = AppStateExited
+		app.State = v1.AppStateExited
 		exitCode := int32(code)
 		app.ExitCode = &exitCode
 	}
@@ -205,18 +206,18 @@ func appStateInImmutablePod(app *App, pod *pkgPod.Pod) error {
 	return nil
 }
 
-func appStateFromPod(pod *pkgPod.Pod) AppState {
+func appStateFromPod(pod *pkgPod.Pod) v1.AppState {
 	switch pod.State() {
 	case pkgPod.Embryo, pkgPod.Preparing, pkgPod.AbortedPrepare:
-		return AppStateUnknown
+		return v1.AppStateUnknown
 	case pkgPod.Prepared:
-		return AppStateCreated
+		return v1.AppStateCreated
 	case pkgPod.Running:
-		return AppStateRunning
+		return v1.AppStateRunning
 	case pkgPod.Deleting, pkgPod.ExitedDeleting, pkgPod.Exited, pkgPod.ExitedGarbage, pkgPod.Garbage:
-		return AppStateExited
+		return v1.AppStateExited
 	default:
-		return AppStateUnknown
+		return v1.AppStateUnknown
 	}
 }
 

--- a/lib/pod.go
+++ b/lib/pod.go
@@ -14,11 +14,14 @@
 
 package rkt
 
-import pkgPod "github.com/rkt/rkt/pkg/pod"
+import (
+	"github.com/rkt/rkt/api/v1"
+	pkgPod "github.com/rkt/rkt/pkg/pod"
+)
 
 // NewPodFromInternalPod converts *pkgPod.Pod to *Pod
-func NewPodFromInternalPod(p *pkgPod.Pod) (*Pod, error) {
-	pod := &Pod{
+func NewPodFromInternalPod(p *pkgPod.Pod) (*v1.Pod, error) {
+	pod := &v1.Pod{
 		UUID:     p.UUID.String(),
 		State:    p.State(),
 		Networks: p.Nets,

--- a/lib/pod.go
+++ b/lib/pod.go
@@ -44,7 +44,19 @@ func NewPodFromInternalPod(p *pkgPod.Pod) (*Pod, error) {
 	}
 
 	for _, app := range manifest.Apps {
+		// for backwards compatibility
 		pod.AppNames = append(pod.AppNames, app.Name.String())
+	}
+
+	var appState appStateFunc
+	if p.IsMutable() {
+		appState = appStateInMutablePod
+	} else {
+		appState = appStateInImmutablePod
+	}
+	pod.Apps, err = appsForPod(p, "", appState)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(manifest.UserAnnotations) > 0 {

--- a/lib/types.go
+++ b/lib/types.go
@@ -73,7 +73,10 @@ type (
 		// Networks are the information of the networks.
 		Networks []netinfo.NetInfo `json:"networks,omitempty"`
 		// AppNames are the names of the apps.
+		// Deprecated: use Apps instead.
 		AppNames []string `json:"app_names,omitempty"`
+		// Apps holds current information about each app.
+		Apps []*App `json:"apps,omitempty"`
 		// The start time of the pod.
 		StartedAt *int64 `json:"started_at,omitempty"`
 		// UserAnnotations are the pod user annotations.

--- a/pkg/pod/pods.go
+++ b/pkg/pod/pods.go
@@ -1211,3 +1211,8 @@ func (p *Pod) AppExitCode(appName string) (int, error) {
 	statusFile := filepath.Join(stage1RootfsPath, "/rkt/status/", appName)
 	return p.readIntFromFile(statusFile)
 }
+
+// IsMutable can be used to determine if a pod is mutable
+func (p *Pod) IsMutable() bool {
+	return p.mutable
+}

--- a/rkt/app_status.go
+++ b/rkt/app_status.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rkt/rkt/api/v1"
 	rkt "github.com/rkt/rkt/lib"
 	"github.com/spf13/cobra"
 )
@@ -39,7 +40,7 @@ func init() {
 	cmdAppStatus.Flags().Var(&flagFormat, "format", "choose the output format, allowed format includes 'json', 'json-pretty'. If empty, then the result is printed as key value pairs")
 }
 
-func printApp(app *rkt.App) {
+func printApp(app *v1.App) {
 	stdout.Printf("name=%s\n", app.Name)
 	stdout.Printf("state=%s\n", app.State)
 	stdout.Printf("image_id=%s\n", app.ImageID)

--- a/rkt/image_list.go
+++ b/rkt/image_list.go
@@ -21,13 +21,12 @@ import (
 	"strings"
 	"time"
 
-	rktlib "github.com/rkt/rkt/lib"
-	rktflag "github.com/rkt/rkt/pkg/flag"
-	"github.com/rkt/rkt/store/imagestore"
-
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/lastditch"
 	"github.com/dustin/go-humanize"
+	"github.com/rkt/rkt/api/v1"
+	rktflag "github.com/rkt/rkt/pkg/flag"
+	"github.com/rkt/rkt/store/imagestore"
 	"github.com/spf13/cobra"
 )
 
@@ -81,7 +80,7 @@ var (
 )
 
 type printableImage struct {
-	rktlib.ImageListEntry
+	v1.ImageListEntry
 
 	format outputFormat
 	full   bool
@@ -301,7 +300,7 @@ func runImages(cmd *cobra.Command, args []string) int {
 		}
 
 		imagesToPrint = append(imagesToPrint, printableImage{
-			ImageListEntry: rktlib.ImageListEntry{
+			ImageListEntry: v1.ImageListEntry{
 				ID:           imageID,
 				Name:         imageName,
 				ImportTime:   aciInfo.ImportTime.UnixNano(),

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -230,10 +230,6 @@ func newPodListReadError(p *pkgPod.Pod, err error) error {
 	return fmt.Errorf("%s", strings.Join(lines, "\n"))
 }
 
-func newPodListZeroAppsError(p *pkgPod.Pod) error {
-	return fmt.Errorf("pod %s contains zero apps", p.UUID.String())
-}
-
 func newPodListLoadImageManifestError(p *pkgPod.Pod, err error) error {
 	return errwrap.Wrap(fmt.Errorf("pod %s ImageManifest could not be loaded", p.UUID.String()), err)
 }

--- a/rkt/list.go
+++ b/rkt/list.go
@@ -28,6 +28,7 @@ import (
 	"github.com/appc/spec/schema/types"
 	"github.com/dustin/go-humanize"
 	"github.com/hashicorp/errwrap"
+	"github.com/rkt/rkt/api/v1"
 	lib "github.com/rkt/rkt/lib"
 	"github.com/rkt/rkt/networking/netinfo"
 	pkgPod "github.com/rkt/rkt/pkg/pod"
@@ -66,7 +67,7 @@ func runList(cmd *cobra.Command, args []string) int {
 		}
 	}
 
-	var pods []*lib.Pod
+	var pods []*v1.Pod
 
 	if err := pkgPod.WalkPods(getDataDir(), pkgPod.IncludeMostDirs, func(p *pkgPod.Pod) {
 		if flagFormat != outputFormatTabbed {


### PR DESCRIPTION
Make `rkt list|status --format=json` compatible with the default `k=v` format and include state info (exit codes in particular).

Also deprecate `App.AppNames` in the json output, but keep it there for backwards compatibility.

Before the change:

```sh-session
$ rkt status --format=json f4ef2301-511f-4ab0-9ce9-fdd02a76798e | jq "."
{
  "name": "f4ef2301-511f-4ab0-9ce9-fdd02a76798e",
  "state": "exited",
  "app_names": [
    "busybox"
  ],
  "started_at": 1491855899
}
```

After the change:

```sh-session
$ rkt status --format=json f4ef2301-511f-4ab0-9ce9-fdd02a76798e | jq "."
{
  "name": "f4ef2301-511f-4ab0-9ce9-fdd02a76798e",
  "state": "exited",
  "app_names": [
    "busybox"
  ],
  "apps": [
    {
      "name": "busybox",
      "state": "exited",
      "created_at": 1491855899323730200,
      "exit_code": 12,
      "image_id": "sha512-4014cef722fd0105ad0b90a95d403a6a236f6c3fa1e45fc8b0deb319d493d524"
    }
  ],
  "started_at": 1491855899
}
```

Signed-off-by: Fabio Kung <fabio.kung@gmail.com>