### PR TITLE
tests: fix image verify on semaphore

### DIFF
--- a/tests/rkt_image_verify_test.go
+++ b/tests/rkt_image_verify_test.go
@@ -22,12 +22,17 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/rkt/rkt/common"
 	"github.com/rkt/rkt/tests/testutils"
 )
 
 // TestImageVerify tests 'rkt image verify'.
 // It renders an image, deletes a file from it, and verifies that 'verify' notices and repairs it.
 func TestImageVerify(t *testing.T) {
+	if err := common.SupportsOverlay(); err != nil {
+		t.Skipf("Overlay fs not supported: %v", err)
+	}
+
 	tmpDir := mustTempDir("rkt-TestImageVerify-")
 	defer os.RemoveAll(tmpDir)
 

--- a/tests/rkt_image_verify_test.go
+++ b/tests/rkt_image_verify_test.go
@@ -59,7 +59,7 @@ func TestImageVerify(t *testing.T) {
 		t.Fatalf("unable to walk treestore %v: %v", treestorePath, err)
 	}
 	if numDeleted != 1 {
-		t.Fatalf("expected to find one 'inspect' binary in the tree to delete")
+		t.Fatalf("expected to find one 'inspect' binary in the tree to delete; found %v", numDeleted)
 	}
 
 	cmd := fmt.Sprintf("%s image verify %s", ctx.Cmd(), imgHash)


### PR DESCRIPTION
Don't merge yet, I'm kicking semaphore to try and figure out why this test was failing there on the golint pr.