### PR TITLE
stage1: improve duplicate mount-volume detection

### DIFF
--- a/stage0/run.go
+++ b/stage0/run.go
@@ -173,9 +173,10 @@ func deduplicateMPs(mounts []schema.Mount) []schema.Mount {
 	var res []schema.Mount
 	seen := make(map[string]struct{})
 	for _, m := range mounts {
-		if _, ok := seen[m.Path]; !ok {
+		cleanPath := path.Clean(m.Path)
+		if _, ok := seen[cleanPath]; !ok {
 			res = append(res, m)
-			seen[m.Path] = struct{}{}
+			seen[cleanPath] = struct{}{}
 		}
 	}
 	return res

--- a/stage1/common/types/pod.go
+++ b/stage1/common/types/pod.go
@@ -131,6 +131,15 @@ func LoadPod(root string, uuid *types.UUID, rp *RuntimePod) (*Pod, error) {
 	}
 	p.Manifest = pm
 
+	// ensure volumes names are unique
+	volNames := make(map[types.ACName]bool, len(pm.Volumes))
+	for _, vol := range pm.Volumes {
+		if volNames[vol.Name] {
+			return nil, fmt.Errorf("duplicate volume name %q", vol.Name)
+		}
+		volNames[vol.Name] = true
+	}
+
 	for i, app := range p.Manifest.Apps {
 		impath := common.ImageManifestPath(p.Root, app.Name)
 		buf, err := ioutil.ReadFile(impath)

--- a/stage1_fly/run/main.go
+++ b/stage1_fly/run/main.go
@@ -157,11 +157,16 @@ func evaluateMounts(rfs string, app string, p *stage1commontypes.Pod) ([]flyMoun
 		// Check if we have a mount for this volume
 		tuple, exists := namedVolumeMounts[v.Name]
 		if !exists {
-			return nil, fmt.Errorf("missing mount for volume %q", v.Name)
-		} else if tuple.M.Volume != v.Name {
-			// assertion regarding the implementation, should never happen
+			diag.Printf("skipping unused volume %q", v.Name)
+			continue
+		}
+
+		// Assertion regarding the implementation, should never happen
+		if tuple.M.Volume != v.Name {
 			return nil, fmt.Errorf("mismatched volume:mount pair: %q != %q", v.Name, tuple.M.Volume)
 		}
+
+		// Augment and replace mount entry, adding volume info
 		namedVolumeMounts[v.Name] = volumeMountTuple{V: v, M: tuple.M}
 		diag.Printf("adding %+v", namedVolumeMounts[v.Name])
 	}

--- a/tests/rkt_volume_mount_fly_test.go
+++ b/tests/rkt_volume_mount_fly_test.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -29,22 +28,5 @@ func TestVolumeMount(t *testing.T) {
 		volumeMountTestCasesNonRecursivePodManifest,
 		volumeMountTestCasesNonRecursive,
 		volumeMountTestCasesDuplicateVolume,
-		{
-			{
-				"CLI: duplicate mount given",
-				[]imagePatch{
-					{
-						"rkt-test-run-read-file.aci",
-						[]string{fmt.Sprintf("--exec=/inspect --read-file --file-name %s", mountFilePath)},
-					},
-				},
-				fmt.Sprintf(
-					"--volume=test1,kind=host,source=%s --mount volume=test1,target=%s --volume=test2,kind=host,source=%s --mount volume=test1,target=%s",
-					volDir, mountDir,
-					volDir, mountDir+"/",
-				),
-				nil,
-				`run: can't evaluate mounts: missing mount for volume "test2"`,
-			},
-		}}).Execute(t)
+	}).Execute(t)
 }

--- a/tests/rkt_volume_mount_fly_test.go
+++ b/tests/rkt_volume_mount_fly_test.go
@@ -28,6 +28,7 @@ func TestVolumeMount(t *testing.T) {
 		volumeMountTestCasesRecursivePodManifest,
 		volumeMountTestCasesNonRecursivePodManifest,
 		volumeMountTestCasesNonRecursive,
+		volumeMountTestCasesDuplicateVolume,
 		{
 			{
 				"CLI: duplicate mount given",
@@ -40,7 +41,7 @@ func TestVolumeMount(t *testing.T) {
 				fmt.Sprintf(
 					"--volume=test1,kind=host,source=%s --mount volume=test1,target=%s --volume=test2,kind=host,source=%s --mount volume=test1,target=%s",
 					volDir, mountDir,
-					volDir, mountDir,
+					volDir, mountDir+"/",
 				),
 				nil,
 				`run: can't evaluate mounts: missing mount for volume "test2"`,

--- a/tests/rkt_volume_mount_generic_test.go
+++ b/tests/rkt_volume_mount_generic_test.go
@@ -28,6 +28,7 @@ func TestVolumeMount(t *testing.T) {
 		volumeMountTestCasesRecursivePodManifest,
 		volumeMountTestCasesNonRecursivePodManifest,
 		volumeMountTestCasesNonRecursive,
+		volumeMountTestCasesDuplicateVolume,
 		{
 			{
 				"CLI: duplicate mount given",
@@ -40,7 +41,7 @@ func TestVolumeMount(t *testing.T) {
 				fmt.Sprintf(
 					"--volume=test1,kind=host,source=%s --mount volume=test1,target=%s --volume=test2,kind=host,source=%s --mount volume=test1,target=%s",
 					volDir, mountDir,
-					volDir, mountDir,
+					volDir, mountDir+"/",
 				),
 				nil,
 				innerFileContent,

--- a/tests/rkt_volume_mount_test.go
+++ b/tests/rkt_volume_mount_test.go
@@ -307,6 +307,21 @@ var (
 			outerFileContent,
 		},
 	}
+
+	volumeMountTestCasesDuplicateVolume = []volumeMountTestCase{
+		{
+			"CLI: duplicate volume name",
+			[]imagePatch{
+				{"rkt-test-run-pod-manifest-duplicate-mount.aci", []string{}},
+			},
+			fmt.Sprintf(
+				"--volume=test,kind=host,source=%s --mount volume=test,target=%s --volume=test,kind=empty --mount volume=test,target=%s",
+				volDir, mountDir, path.Join(mountDir, "dup"),
+			),
+			nil,
+			"duplicate volume name",
+		},
+	}
 )
 
 func NewTestVolumeMount(volumeMountTestCases [][]volumeMountTestCase) testutils.Test {


### PR DESCRIPTION
Breaking change: volumes with duplicate names are now rejected.

This PR adds error-checking for duplicate volume names. Also, it adds path cleaning when de-duplicating mounts targets. Tests are slightly adjusted to check both cases.

Fixes https://github.com/rkt/rkt/issues/3663