### PR TITLE
docs: correct rkt pronunciation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ![rkt Logo](logos/rkt-horizontal-color.png)
 
-rkt (pronounced _"rock-it"_) is a CLI for running application containers on Linux. rkt is designed to be secure, composable, and standards-based.
+rkt (pronounced like a _"rocket"_) is a CLI for running application containers on Linux. rkt is designed to be secure, composable, and standards-based.
 
 Some of rkt's key features and goals include:
 


### PR DESCRIPTION
`rkt` has an icon of a rocket but previously the official pronunciation was "rock-it" which is incompatible with the logo. This change fixes that.

Fixes #3673 