### PR TITLE
fix(doc): how to get password for the ubuntu user

### DIFF
--- a/Documentation/trying-out-rkt.md
+++ b/Documentation/trying-out-rkt.md
@@ -61,6 +61,9 @@ vagrant up --provider=libvirt
 
 With a subsequent `vagrant ssh` you will have access to run rkt:
 
+If you are running an outdated version of VirtualBox, it may be that SSH asks for a password. You can find the password for the `ubuntu` user in `~/.vagrant.d/boxes/ubuntu-VAGRANTSLASH-xenial64/[DATE]/virtualbox/Vagrantfile`
+under `config.ssh.password`.
+
 ```
 vagrant ssh
 rkt --help


### PR DESCRIPTION
Mac OS 10.12.3
Vagrant 1.9.4
VirtualBox 5.0.8

After following instructions to set up a Vagrant machine to try `rkt` (`git clone`, `vagrant up`), I could not login in the machine via `vagrant ssh` since it asked me for a password.

It was a bit painful to find so I added instructions in the documentation on how to get it.