### PR TITLE
functional test: Fix manifest arch error

### DIFF
--- a/tests/functional.mk
+++ b/tests/functional.mk
@@ -187,8 +187,7 @@ $$(call forward-vars,$2/manifest,ABS_GO)
 $2/manifest: $4 | $2
 	$$(VQ) \
 	$$(call vb,v2,GEN,$$(call vsp,$$@)) \
-	GOARCH="$$$$($$(ABS_GO) env GOARCH)"; \
-	sed -e "s/@GOOS@/linux/" -e "s/@GOARCH@/$$$$GOARCH/" <$$< >$$@
+	sed -e "s/@GOOS@/linux/" -e "s/@GOARCH@/$${RKT_ACI_ARCH}/" <$$< >$$@
 
 $$(call forward-vars,$1,ACTOOL)
 $1: $2/manifest $2/rootfs/ace-validator | $2/rootfs/opt/acvalidator


### PR DESCRIPTION
The manifest contains values for the ACI arch and OS, not the go
language values.

Fixes 'make check' errors like these when run an ARM64 machines:

    build: Layout failed validation: image manifest validation failed: bad arch "arm64" for linux (must be one of: [amd64 i386 aarch64 aarch64_be armv6l armv7l armv7b ppc64 ppc64le s390x])