### PR TITLE
imagestore: Fix sql resource leaks

### DIFF
--- a/store/imagestore/aciinfo.go
+++ b/store/imagestore/aciinfo.go
@@ -71,6 +71,7 @@ func GetACIInfosWithKeyPrefix(tx *sql.Tx, prefix string) ([]*ACIInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		aciinfo := &ACIInfo{}
 		if err := aciinfoRowScan(rows, aciinfo); err != nil {
@@ -93,6 +94,7 @@ func GetACIInfosWithName(tx *sql.Tx, name string) ([]*ACIInfo, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		found = true
 		aciinfo := &ACIInfo{}
@@ -116,6 +118,7 @@ func GetACIInfoWithBlobKey(tx *sql.Tx, blobKey string) (*ACIInfo, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		found = true
 		if err := aciinfoRowScan(rows, aciinfo); err != nil {
@@ -147,6 +150,7 @@ func GetAllACIInfos(tx *sql.Tx, sortfields []string, ascending bool) ([]*ACIInfo
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		aciinfo := &ACIInfo{}
 		if err := aciinfoRowScan(rows, aciinfo); err != nil {

--- a/store/imagestore/migrate_test.go
+++ b/store/imagestore/migrate_test.go
@@ -466,6 +466,7 @@ func getAllACIInfosV0_2(tx *sql.Tx) ([]*ACIInfoV0_2, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		aciinfo := &ACIInfoV0_2{}
 		if err := rows.Scan(&aciinfo.BlobKey, &aciinfo.AppName, &aciinfo.ImportTime, &aciinfo.Latest); err != nil {
@@ -485,6 +486,7 @@ func getAllACIInfosV3(tx *sql.Tx) ([]*ACIInfoV3, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		aciinfo := &ACIInfoV3{}
 		if rows.Scan(&aciinfo.BlobKey, &aciinfo.Name, &aciinfo.ImportTime, &aciinfo.Latest); err != nil {
@@ -504,6 +506,7 @@ func getAllACIInfosV4(tx *sql.Tx) ([]*ACIInfoV4, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		aciinfo := &ACIInfoV4{}
 		if rows.Scan(&aciinfo.BlobKey, &aciinfo.Name, &aciinfo.ImportTime, &aciinfo.LastUsed, &aciinfo.Latest); err != nil {
@@ -523,6 +526,7 @@ func getAllACIInfosV5(tx *sql.Tx) ([]*ACIInfoV5, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		aciinfo := &ACIInfoV5{}
 		if rows.Scan(&aciinfo.BlobKey, &aciinfo.Name, &aciinfo.ImportTime, &aciinfo.LastUsed, &aciinfo.Latest, &aciinfo.Size, &aciinfo.TreeStoreSize); err != nil {
@@ -542,6 +546,7 @@ func getAllACIInfosV6(tx *sql.Tx) ([]*ACIInfoV6, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		aciinfo := &ACIInfoV6{}
 		if rows.Scan(&aciinfo.BlobKey, &aciinfo.Name, &aciinfo.ImportTime, &aciinfo.LastUsed, &aciinfo.Latest, &aciinfo.Size, &aciinfo.TreeStoreSize, &aciinfo.InsecureOptions); err != nil {
@@ -561,6 +566,7 @@ func getAllACIInfosV7(tx *sql.Tx) ([]*ACIInfoV7, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		aciinfo := &ACIInfoV7{}
 		if rows.Scan(&aciinfo.BlobKey, &aciinfo.Name, &aciinfo.ImportTime, &aciinfo.LastUsed, &aciinfo.Latest, &aciinfo.Size, &aciinfo.TreeStoreSize); err != nil {
@@ -587,6 +593,7 @@ func getAllRemoteV0_1(tx *sql.Tx) ([]*RemoteV0_1, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		remote := &RemoteV0_1{}
 		if err := rows.Scan(&remote.ACIURL, &remote.SigURL, &remote.ETag, &remote.BlobKey); err != nil {
@@ -615,6 +622,7 @@ func getAllRemoteV2_7(tx *sql.Tx) ([]*RemoteV2_7, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		remote := &RemoteV2_7{}
 		if err := rows.Scan(&remote.ACIURL, &remote.SigURL, &remote.ETag, &remote.BlobKey, &remote.CacheMaxAge, &remote.DownloadTime); err != nil {

--- a/store/imagestore/remote.go
+++ b/store/imagestore/remote.go
@@ -58,6 +58,7 @@ func GetRemote(tx *sql.Tx, aciURL string) (*Remote, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	if ok := rows.Next(); !ok {
 		return nil, ErrRemoteNotFound
@@ -86,6 +87,7 @@ func GetAllRemotes(tx *sql.Tx) ([]*Remote, error) {
 		return nil, err
 
 	}
+	defer rows.Close()
 
 	for rows.Next() {
 		r := &Remote{}

--- a/store/imagestore/schema.go
+++ b/store/imagestore/schema.go
@@ -48,6 +48,7 @@ func dbIsPopulated(tx *sql.Tx) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer rows.Close()
 	count := 0
 	for rows.Next() {
 		count++
@@ -68,6 +69,7 @@ func getDBVersion(tx *sql.Tx) (int, error) {
 	if err != nil {
 		return -1, err
 	}
+	defer rows.Close()
 	found := false
 	for rows.Next() {
 		if err := rows.Scan(&version); err != nil {


### PR DESCRIPTION
When using sql queries the rows iterator needs to be closed if the entire query
result is not iterated over.  Failure to close the iterator results in resource
leakage.

Fixes errors like these seen with go1.8.1:

    Too many goroutines running after integration test(s).
    database/sql.(*Rows).awaitDone(0xc4201d9200, 0xd64000, 0xc4201e9b40)
            database/sql/sql.go:2121
    created by database/sql.(*Rows).initContextClose
            database/sql/sql.go:2116

See: https://golang.org/pkg/database/sql/#Rows