### PR TITLE
network: do not automatically add `default*` networks when custom ones are specified

### DIFF
--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -1125,7 +1125,7 @@ func NewNetOverrideTest() testutils.Test {
 
 		expectedIP := "11.11.4.244"
 
-		cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=all --net=\"%s:IP=%s\" --mds-register=false %s", ctx.Cmd(), nt.Name, expectedIP, testImage)
+		cmd := fmt.Sprintf("%s --debug --insecure-options=image run --net=\"%s:IP=%s\" --mds-register=false %s", ctx.Cmd(), nt.Name, expectedIP, testImage)
 		child := spawnOrFail(t, cmd)
 		defer waitOrFail(t, child, 0)
 

--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -1318,19 +1318,11 @@ func NewNetPreserveNetNameTest() testutils.Test {
 			t.Fatalf("Can't open net-info.json for reading: %v", err)
 		}
 
-		if len(info) != 2 {
+		if len(info) != 1 {
 			t.Fatalf("Incorrect number of networks: %v", len(info))
 		}
 
-		found := false
-		for _, net := range info {
-			if net.NetName == ntFlannel.Name {
-				found = true
-				break
-			}
-		}
-
-		if !found {
+		if info[0].NetName != ntFlannel.Name {
 			t.Fatalf("Network '%s' not found!\nnetInfo[0]: %v\nnetInfo[1]: %v", ntFlannel.Name, info[0], info[1])
 		}
 	})


### PR DESCRIPTION
BREAKING: do not automatically add `default*` networks when custom ones are specified

Currently, a network named `"default"` (or `"default-restricted"`) is always added to Pods, even when `--net=custom1,custom2,...` was passed in. E.g.:

```
$ rkt --insecure-options=image run docker://alpine --net=custom1 --exec /bin/sh -- -c "ip link show"
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
3: eth0@if91: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc tbf state UP
    link/ether 0a:58:c0:a8:02:03 brd ff:ff:ff:ff:ff:ff
5: eth1@if92: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
    link/ether e2:a1:b3:c1:e7:24 brd ff:ff:ff:ff:ff:ff
```

The container in that case should only have `lo` and `eth0`, not `eth1`.

The current behavior (a default network is always added) is not what is specified on docs (`Documentation/networking/overview.md`):

```
**Note**: The default network must be explicitly listed in order to be loaded when `--net=n1,n2,...` is specified with a list of network names.

Example: If you want default networking and two more networks you need to pass `--net=default,net1,net2`.
```

Signed-off-by: Fabio Kung <fabio.kung@gmail.com>