### PR TITLE
scripts/pkg: improved detection of active mounts

### DIFF
--- a/scripts/pkg/after-remove
+++ b/scripts/pkg/after-remove
@@ -1,2 +1,7 @@
-rm -rf /var/lib/rkt
+if test `stat -c%d "/var/lib/rkt"` == `stat -c%d "/var/lib"`; then
+    rm -rf /var/lib/rkt
+else
+    # is a mountpoint, so just delete contents
+    rm -rf /var/lib/rkt/*
+fi
 systemctl daemon-reload || true

--- a/scripts/pkg/before-remove
+++ b/scripts/pkg/before-remove
@@ -4,7 +4,7 @@ if [ -f /usr/bin/rkt ]; then
         exit 1
     fi
     /usr/bin/rkt gc --grace-period=0s
-    if [ -n "$(grep "/var/lib/rkt" /proc/mounts)" ]; then
+    if [ -n "$(grep "/var/lib/rkt/pods/run/" /proc/mounts)" ]; then
         printf "rkt/before-remove error: detected active mounts in [/var/lib/rkt].\n"
         exit 1
     fi


### PR DESCRIPTION
On systems which have /var/lib/rkt as a separate partition, the active
mount detection in before-remove needs to not get confused by the
presence of /var/lib/rkt itself as a mount.  Therefore a longer path
is used for active mount detection.

Fixes #3706