### PR TITLE
stage0/status: fix failure when systemd never runs in stage1

### DIFF
--- a/Documentation/subcommands/status.md
+++ b/Documentation/subcommands/status.md
@@ -14,6 +14,10 @@ app-redis=0
 app-etcd=0
 ```
 
+Note that `pid` may not be available shortly after `rkt run`, or `rkt run-prepared`, even when `state=running`.
+
+The `--wait` flags below can be used to wait for a Pod to be running with its pid captured.
+
 If the pod is still running, you can wait for it to finish and then get the status with `rkt status --wait UUID`.
 To wait for the pod to become ready, execute `rkt status --wait-ready`.
 Both options also accept a duration. To wait up to 10 seconds until the pod is finished, execute `rkt status --wait=10s UUID`.


### PR DESCRIPTION
A pid file never gets written if systemd never gets to run in stage1. This can happen if the image had a bad command, i.e.: not in $PATH.

Steps to reproduce:

```
$ sudo rkt --insecure-options=image run --uuid-file-save=/tmp/id docker://alpine --exec=bad
stage1: cannot initialize immutable environment: unable to find "bad" in "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

$ sudo rkt status $(cat /tmp/id)
state=exited
created=2017-06-16 16:34:27.38 -0700 PDT
status: unable to print status: unable to get PID for pod "e6ccefea-1cdf-459a-b98d-7da95373a7d2": <nil>
```

Signed-off-by: Fabio Kung <fabio.kung@gmail.com>