### PR TITLE
networking: change the default-restricted subnet

### DIFF
--- a/stage1/net/rootfs/etc/rkt/net.d/99-default-restricted.conf
+++ b/stage1/net/rootfs/etc/rkt/net.d/99-default-restricted.conf
@@ -5,6 +5,6 @@
 	"ipMasq": false,
 	"ipam": {
 		"type": "host-local",
-		"subnet": "172.17.0.0/16"
+		"subnet": "172.31.0.0/16"
 	}
 }

--- a/tests/rkt_net_test.go
+++ b/tests/rkt_net_test.go
@@ -1171,7 +1171,7 @@ func NewNetDefaultIPArgTest() testutils.Test {
 	}
 	return testutils.TestFunc(func(t *testing.T) {
 		doTest("default:IP=172.16.28.123", "172.16.28.123", t)
-		doTest("default-restricted:IP=172.17.42.42", "172.17.42.42", t)
+		doTest("default-restricted:IP=172.31.42.42", "172.31.42.42", t)
 	})
 }
 


### PR DESCRIPTION
Previously, we were using 172.17/16, which conflicts with the default
Docker networking. Change it to 172.31/16.