### PR TITLE
stage1/init/units: keep journald running while apps are shutting down

### DIFF
--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -169,6 +169,7 @@ func ImmutableEnv(p *stage1commontypes.Pod) error {
 		}
 
 		uw.AppUnit(ra, binPath,
+			unit.NewUnitOption("Unit", "After", "systemd-journald.service"),
 			// When an app fails, we shut down the pod
 			unit.NewUnitOption("Unit", "OnFailure", "halt.target"))
 


### PR DESCRIPTION
This prevents a race when apps are writing to their stdout/err (and
output is being sent to stage1's journal) while shutting down. If
journald terminates before the apps finish shutting down, their output
will be lost.

Signed-off-by: Fabio Kung <fabio.kung@gmail.com>