### PR TITLE
[WIP] stage1/logging: introduce a new journal logging mode

### DIFF
--- a/Documentation/devel/log-attach-design.md
+++ b/Documentation/devel/log-attach-design.md
@@ -185,6 +185,12 @@ A sidecar dependency to `systemd-journald.service` is introduced in this case. A
 
 Logging is not a valid mode for stdin.
 
+
+### Journal mode
+
+This is similar to the logging mode above. Additionally, the pod-level journal will be available read-only inside each
+app at `/var/log/journal`.
+
 ### Null mode
 
 This mode results in the application having the corresponding stream closed.
@@ -232,12 +238,14 @@ The following per-app annotations are defined for internal use, with the corresp
  * `coreos.com/rkt/stage2/stdout`
    - `interactive`
    - `log`
+   - `journal`
    - `null`
    - `stream`
    - `tty`
  * `coreos.com/rkt/stage2/stderr`
    - `interactive`
    - `log`
+   - `journal`
    - `null`
    - `stream`
    - `tty`

--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -238,6 +238,7 @@ func (uw *UnitWriter) SetupAppIO(p *stage1commontypes.Pod, ra *schema.RuntimeApp
 	var iottymuxEnvFlags []string
 	needsIOMux := false
 	needsTTYMux := false
+	needsJournal := false
 
 	switch stdin {
 	case "stream":
@@ -272,6 +273,9 @@ func (uw *UnitWriter) SetupAppIO(p *stage1commontypes.Pod, ra *schema.RuntimeApp
 		opts = append(opts, unit.NewUnitOption("Service", "StandardOutput", "tty"))
 	case "null":
 		opts = append(opts, unit.NewUnitOption("Service", "StandardOutput", "null"))
+	case "journal":
+		needsJournal = true
+		opts = append(opts, unit.NewUnitOption("Service", "StandardOutput", "journal"))
 	default:
 		// log mode
 		opts = append(opts, unit.NewUnitOption("Service", "StandardOutput", "journal+console"))
@@ -292,6 +296,9 @@ func (uw *UnitWriter) SetupAppIO(p *stage1commontypes.Pod, ra *schema.RuntimeApp
 		opts = append(opts, unit.NewUnitOption("Service", "StandardError", "tty"))
 	case "null":
 		opts = append(opts, unit.NewUnitOption("Service", "StandardError", "null"))
+	case "journal":
+		needsJournal = true
+		opts = append(opts, unit.NewUnitOption("Service", "StandardError", "journal"))
 	default:
 		// log mode
 		opts = append(opts, unit.NewUnitOption("Service", "StandardError", "journal+console"))
@@ -330,6 +337,10 @@ func (uw *UnitWriter) SetupAppIO(p *stage1commontypes.Pod, ra *schema.RuntimeApp
 			opts = append(opts, unit.NewUnitOption("Unit", "Requires", fmt.Sprintf("ttymux@%s.service", ra.Name)))
 			opts = append(opts, unit.NewUnitOption("Unit", "After", fmt.Sprintf("ttymux@%s.service", ra.Name)))
 		}
+	}
+
+	if needsJournal {
+		opts = append(opts, unit.NewUnitOption("Service", "BindReadOnlyPaths", "/var/log/journal"))
 	}
 	return opts
 }

--- a/stage1/prepare-app/prepare-app.c
+++ b/stage1/prepare-app/prepare-app.c
@@ -282,6 +282,9 @@ int main(int argc, char *argv[])
 		dir("run",			0755),
 		dir("run/systemd",		0755),
 		dir("run/systemd/journal",	0755),
+		dir("var",			0755),
+		dir("var/log",			0755),
+		dir("var/log/journal",		0755),
 	};
 	static const char *devnodes[] = {
 		"/dev/null",
@@ -299,6 +302,7 @@ int main(int argc, char *argv[])
 		{ "/dev/shm", "/dev/shm", "bind", NULL, MS_BIND, false },
 		{ "/dev/pts", "/dev/pts", "bind", NULL, MS_BIND, false },
 		{ "/run/systemd/journal", "/run/systemd/journal", "bind", NULL, MS_BIND, false },
+		{ "/var/log/journal", "/var/log/journal", "bind", NULL, MS_BIND|MS_RDONLY, false },
 		/* /sys is handled separately */
 	};
 	static const mount_point files_mount_table[] = {

--- a/tests/rkt_machine_id_test.go
+++ b/tests/rkt_machine_id_test.go
@@ -1,0 +1,62 @@
+// Copyright 2016 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build host coreos src kvm
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rkt/rkt/tests/testutils"
+)
+
+// TestMachineID test that /etc/machine-id gets created/written with the Pod uuid.
+func TestMachineID(t *testing.T) {
+	imageFile := patchTestACI("rkt-inspect-machine-id.aci", "--exec=/inspect --read-file")
+	defer os.Remove(imageFile)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	rktCmd := fmt.Sprintf(
+		"%s prepare --insecure-options=image %s --environment=FILE=/etc/machine-id",
+		ctx.Cmd(), imageFile,
+	)
+	uuid := runRktAndGetUUID(t, rktCmd)
+	rktCmd = fmt.Sprintf("%s run-prepared %s", ctx.Cmd(), uuid)
+	expected := strings.Replace(uuid, "-", "", -1)
+	runRktAndCheckOutput(t, rktCmd, expected, false)
+}
+
+// TestMachineID test that /etc/machine-id gets created/written on a readonly rootfs.
+func TestMachineIDReadOnly(t *testing.T) {
+	imageFile := patchTestACI("rkt-inspect-machine-id-ro.aci", "--exec=/inspect --read-file")
+	defer os.Remove(imageFile)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	rktCmd := fmt.Sprintf(
+		"%s prepare --insecure-options=image %s --readonly-rootfs=true --environment=FILE=/etc/machine-id",
+		ctx.Cmd(), imageFile,
+	)
+	uuid := runRktAndGetUUID(t, rktCmd)
+	rktCmd = fmt.Sprintf("%s run-prepared %s", ctx.Cmd(), uuid)
+	expected := strings.Replace(uuid, "-", "", -1)
+	runRktAndCheckOutput(t, rktCmd, expected, false)
+}


### PR DESCRIPTION
It is similar to the existing `log` mode that forwards all logs to systemd, with the difference that output will not show up on the console as well (StanddardOutput|Error=journal instead of journal+console).

In addition to that, a read-only view of the pod journal will be bind mounted inside each app, so one more apps can decide to forward output from the pod reading that journal.

Signed-off-by: Fabio Kung <fabio.kung@gmail.com>