### PR TITLE
stage1/units: allow graceful shutdown

### DIFF
--- a/Documentation/devel/stage1-implementors-guide.md
+++ b/Documentation/devel/stage1-implementors-guide.md
@@ -306,6 +306,12 @@ In that case, this information is persisted at runtime in each application manif
  - `coreos.com/rkt/stage2/stdout`
  - `coreos.com/rkt/stage2/stderr`
 
+### Systemd kill configuration
+
+Stage1 images using systemd can read configuration related to how units should be terminated - per `systemd.kill(5)` - from the following annotations:
+ - `coreos.com/rkt/systemd/kill/mode` - `KillMode` in `systemd.kill(5)`
+ - `coreos.com/rkt/systemd/kill/timeout` - `TimeoutStopSec` in `systemd.service(5)`
+
 ## Filesystem Layout Assumptions
 
 The following paths are reserved for the stage1 image, and they will be populated at runtime.

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -67,17 +67,19 @@ c9fad0e6-8236-4fc2-ad17-55d0a4c7d742
 | `--pod-manifest` | none | A path | The path to the pod manifest. If it's non-empty, then only `--net`, `--no-overlay` and `--interactive` will have effect. |
 | `--port` | none | A port name and number pair | Container port name to expose through host port number. Requires [contained network][contained]. Syntax: `--port=NAME:HOSTPORT` The NAME is that given in the ACI. By convention, Docker containers' EXPOSEd ports are given a name formed from the port number, a hyphen, and the protocol, e.g., `80-tcp`, giving something like `--port=80-tcp:8080` |
 | `--private-users` |  `false` | `true` or `false` | Run within user namespaces |
-| `--quiet` |  `false` | `true` or `false` | Suppress superfluous output on stdout, print only the UUID on success |
-| `--set-env` |  `` | An environment variable. Syntax `NAME=VALUE` | An environment variable to set for apps |
-| `--set-env-file` |  `` | Path of an environment variables file | Environment variables to set for apps |
-| `--signature` |  `` | A file path | Local signature file to use in validating the preceding image |
-| `--stage1-url` |  `` | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported | Image to use as stage1 |
-| `--stage1-path` |  `` | A path to a stage1 image. Absolute and relative paths are supported | Image to use as stage1 |
-| `--stage1-name` |  `` | A name of a stage1 image. Will perform a discovery if the image is not in the store | Image to use as stage1 |
-| `--stage1-hash` |  `` | A hash of a stage1 image. The image must exist in the store | Image to use as stage1 |
-| `--stage1-from-dir` |  `` | A stage1 image file inside the default stage1 images directory | Image to use as stage1 |
+| `--quiet` | `false` | `true` or `false` | Suppress superfluous output on stdout, print only the UUID on success |
+| `--set-env` | `` | An environment variable. Syntax `NAME=VALUE` | An environment variable to set for apps |
+| `--set-env-file` | `` | Path of an environment variables file | Environment variables to set for apps |
+| `--signature` | `` | A file path | Local signature file to use in validating the preceding image |
+| `--stage1-url` | `` | A URL to a stage1 image. HTTP/HTTPS/File/Docker URLs are supported | Image to use as stage1 |
+| `--stage1-path` | `` | A path to a stage1 image. Absolute and relative paths are supported | Image to use as stage1 |
+| `--stage1-name` | `` | A name of a stage1 image. Will perform a discovery if the image is not in the store | Image to use as stage1 |
+| `--stage1-hash` | `` | A hash of a stage1 image. The image must exist in the store | Image to use as stage1 |
+| `--stage1-from-dir` | `` | A stage1 image file inside the default stage1 images directory | Image to use as stage1 |
 | `--user` | none | uid, username or file path | user override for the preceding image (example: '--user=user') |
-| `--volume` |  `` | Volume syntax (`NAME,kind=KIND,source=PATH,readOnly=BOOL,recursive=BOOL`). See [Mount Volumes into a Pod][mount-vol] | Volumes to make available in the pod |
+| `--volume` | `` | Volume syntax (`NAME,kind=KIND,source=PATH,readOnly=BOOL,recursive=BOOL`). See [Mount Volumes into a Pod][mount-vol] | Volumes to make available in the pod |
+| `--kill-mode` | `all` | 'all' or 'leader' | How to signal (kill) processes in the app. A SIGTERM is sent to 'all' processes or only the 'leader' (exec command), then a SIGKILL to remaining processes |
+| `--kill-timeout` | `90s` | A duration | How long to wait after sending SIGTERMs for the app to stop before sending SIGKILLs to remaining processes |
 
 ## Global options
 

--- a/Documentation/subcommands/run.md
+++ b/Documentation/subcommands/run.md
@@ -422,6 +422,8 @@ This feature will be disabled automatically if the underlying filesystem does no
 | `--user` | none | uid, username or file path (e.g. `--user=core`) | User override for the preceding image. |
 | `--uuid-file-save` | none | A file path | Write out the pod UUID to a file. |
 | `--volume` | none | Volume syntax (e.g. `--volume NAME,kind=KIND,source=PATH,readOnly=BOOL`) | Volumes to make available in the pod. See [Mount Volumes into a Pod](#mount-volumes-into-a-pod). |
+| `--kill-mode` | `all` | 'all' or 'leader' | How to signal (kill) processes in the app. A SIGTERM is sent to 'all' processes or only the 'leader' (exec command), then a SIGKILL to remaining processes |
+| `--kill-timeout` | `90s` | A duration | How long to wait after sending SIGTERMs for the app to stop before sending SIGKILLs to remaining processes |
 
 ## Per-application options
 

--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"time"
+
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
 )
@@ -37,12 +39,25 @@ func (a AppIO) String() string {
 	return string(a)
 }
 
+// stdin/out/err modes
 const (
 	AppIOInteractive AppIO = "interactive" // interactive I/O (parent terminal)
 	AppIOLog         AppIO = "log"         // log-only I/O
 	AppIONull        AppIO = "null"        // null I/O
 	AppIOStream      AppIO = "stream"      // attachable I/O
 	AppIOTTY         AppIO = "tty"         // I/O over TTY
+)
+
+type KillMode string
+
+func (a KillMode) String() string {
+	return string(a)
+}
+
+// stop signaling behavior
+const (
+	KillModeAll    KillMode = "control-group"
+	KillModeLeader KillMode = "mixed"
 )
 
 type App struct {
@@ -66,6 +81,8 @@ type App struct {
 	UserAnnotations   map[string]string                 // the user annotations of the app.
 	UserLabels        map[string]string                 // the user labels of the app.
 	Environments      map[string]string                 // the environments of the app.
+	KillMode          KillMode                          // how to kill processes when stopping the app
+	KillTimeout       time.Duration                     // how long to wait between SIGTERM and SIGKILL
 	Stdin             AppIO                             // mode for stdin
 	Stdout            AppIO                             // mode for stdout
 	Stderr            AppIO                             // mode for stderr

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/rkt/rkt/common/apps"
@@ -793,6 +794,66 @@ func (au *appSupplementaryGIDs) String() string {
 
 func (au *appSupplementaryGIDs) Type() string {
 	return "appSupplementaryGIDs"
+}
+
+type appKillMode apps.Apps
+
+func (au *appKillMode) Set(s string) error {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return fmt.Errorf("--kill-mode must follow an image")
+	}
+	switch s {
+	case "all":
+		app.KillMode = apps.KillModeAll
+	case "leader":
+		app.KillMode = apps.KillModeLeader
+	default:
+		return fmt.Errorf("--kill-mode=%s is not supported. It must be 'all' or 'leader'", s)
+	}
+	return nil
+}
+
+func (au *appKillMode) String() string {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return ""
+	}
+	if app.KillMode == apps.KillModeLeader {
+		return "leader"
+	}
+	return "all"
+}
+
+func (au *appKillMode) Type() string {
+	return "appKillMode"
+}
+
+type appKillTimeout apps.Apps
+
+func (au *appKillTimeout) Set(s string) error {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return fmt.Errorf("--kill-timeout must follow an image")
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	app.KillTimeout = d
+	return nil
+}
+
+func (au *appKillTimeout) String() string {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return ""
+	}
+	return app.KillTimeout.String()
+}
+
+func (au *appKillTimeout) Type() string {
+	return "appKillTimeout"
 }
 
 // `--stdin=mode` flag

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -110,6 +110,8 @@ func addAppFlags(cmd *cobra.Command) {
 	cmd.Flags().Var((*appAnnotation)(&rktApps), "user-annotation", "set the app's annotations (example: '--user-annotation=foo=bar')")
 	cmd.Flags().Var((*appLabel)(&rktApps), "user-label", "set the app's labels (example: '--user-label=foo=bar')")
 	cmd.Flags().Var((*appEnv)(&rktApps), "environment", "set the app's environment variables (example: '--environment=foo=bar')")
+	cmd.Flags().Var((*appKillMode)(&rktApps), "kill-mode", "set the app's stop signaling behavior. Allowed: 'all' (default), 'leader' (example: '--kill-mode=leader')")
+	cmd.Flags().Var((*appKillTimeout)(&rktApps), "kill-timeout", "duration to wait after SIGTERMs before SIGKILLs (example: '--kill-timeout=15s')")
 	if common.IsExperimentEnabled("attach") {
 		cmd.Flags().Var((*appStdin)(&rktApps), "stdin", "stdin mode for the preceding application (example: '--stdin=null')")
 		cmd.Flags().MarkHidden("stdin")

--- a/stage0/common.go
+++ b/stage0/common.go
@@ -172,6 +172,13 @@ func generateRuntimeApp(appRunConfig *apps.App, am *schema.ImageManifest, podMou
 		ra.App.UserLabels = appRunConfig.UserLabels
 	}
 
+	if m := appRunConfig.KillMode; m != "" {
+		ra.Annotations.Set(stage1types.AppKillMode, m.String())
+	}
+	if d := appRunConfig.KillTimeout; d > 0 {
+		ra.Annotations.Set(stage1types.AppKillTimeout, strconv.Itoa(int(d.Seconds())))
+	}
+
 	if appRunConfig.Stdin != "" {
 		ra.Annotations.Set(stage1types.AppStdinMode, appRunConfig.Stdin.String())
 	}

--- a/stage1/app_add/app_add.go
+++ b/stage1/app_add/app_add.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/coreos/go-systemd/unit"
 	"github.com/hashicorp/errwrap"
 	"github.com/rkt/rkt/common"
 	"github.com/rkt/rkt/pkg/fs"
@@ -130,10 +129,7 @@ func appAddStage0(appName *types.ACName, uuid *types.UUID) error {
 
 	// write service files
 	w := stage1init.NewUnitWriter(p)
-	w.AppUnit(ra, binPath,
-		unit.NewUnitOption("Unit", "Before", "halt.target"),
-		unit.NewUnitOption("Unit", "Conflicts", "halt.target"),
-	)
+	w.AppUnit(ra, binPath)
 	w.AppReaperUnit(ra.Name, binPath)
 	if err := w.Error(); err != nil {
 		return errwrap.Wrapf("error generating app units", err)

--- a/stage1/common/types/pod.go
+++ b/stage1/common/types/pod.go
@@ -29,14 +29,20 @@ import (
 	"github.com/hashicorp/errwrap"
 )
 
-const (
-	// The filename where we persist the RuntimePod data
-	RuntimeConfigPath = "runtime-config"
+// The filename where we persist the RuntimePod data
+const RuntimeConfigPath = "runtime-config"
 
-	// App-level annotations: streams mode
+// App-level annotations: streams mode
+const (
 	AppStdinMode  = "coreos.com/rkt/stage2/stdin"
 	AppStdoutMode = "coreos.com/rkt/stage2/stdout"
 	AppStderrMode = "coreos.com/rkt/stage2/stderr"
+)
+
+// App-level annotations: systemd kill/stop behavior
+const (
+	AppKillMode    = "coreos.com/rkt/systemd/kill/mode"
+	AppKillTimeout = "coreos.com/rkt/systemd/kill/timeout"
 )
 
 // Pod encapsulates a PodManifest and ImageManifests

--- a/stage1/init/common/app.go
+++ b/stage1/init/common/app.go
@@ -45,6 +45,10 @@ type preparedApp struct {
 	capabilities    []string
 	seccomp         *seccompFilter
 
+	// systemd kill behavior
+	killTimeout string
+	killMode    string
+
 	// Path restrictions
 	roPaths     []string
 	hiddenPaths []string
@@ -118,6 +122,13 @@ func prepareApp(p *stage1commontypes.Pod, ra *schema.RuntimeApp) (*preparedApp, 
 	pa.env.Set("AC_APP_NAME", ra.Name.String())
 	if p.MetadataServiceURL != "" {
 		pa.env.Set("AC_METADATA_URL", p.MetadataServiceURL)
+	}
+
+	if m, ok := ra.Annotations.Get(stage1commontypes.AppKillMode); ok {
+		pa.killMode = m
+	}
+	if t, ok := ra.Annotations.Get(stage1commontypes.AppKillTimeout); ok {
+		pa.killTimeout = t
 	}
 
 	// Determine capability set

--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -487,7 +487,6 @@ func (uw *UnitWriter) AppUnit(ra *schema.RuntimeApp, binPath string, opts ...*un
 
 	// Some pre-start jobs take a long time, set the timeout to 0
 	opts = append(opts, unit.NewUnitOption("Service", "TimeoutStartSec", "0"))
-
 	opts = append(opts, unit.NewUnitOption("Unit", "Requires", "sysusers.service"))
 	opts = append(opts, unit.NewUnitOption("Unit", "After", "sysusers.service"))
 
@@ -544,6 +543,13 @@ func (uw *UnitWriter) appSystemdUnit(pa *preparedApp, binPath string, opts []*un
 		unit.NewUnitOption("Unit", "Requires", InstantiatedPrepareAppUnitName(ra.Name)),
 		unit.NewUnitOption("Unit", "After", InstantiatedPrepareAppUnitName(ra.Name)),
 	)
+
+	if t := pa.killTimeout; t != "" {
+		opts = append(opts, unit.NewUnitOption("Service", "TimeoutStopSec", t))
+	}
+	if m := pa.killMode; m != "" {
+		opts = append(opts, unit.NewUnitOption("Service", "KillMode", m))
+	}
 
 	if len(supplementaryGroups) > 0 {
 		opts = appendOptionsList(opts, "Service", "SupplementaryGroups", "", supplementaryGroups...)

--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -169,7 +169,6 @@ func ImmutableEnv(p *stage1commontypes.Pod) error {
 		}
 
 		uw.AppUnit(ra, binPath,
-			unit.NewUnitOption("Unit", "After", "systemd-journald.service"),
 			// When an app fails, we shut down the pod
 			unit.NewUnitOption("Unit", "OnFailure", "halt.target"))
 
@@ -466,9 +465,10 @@ func (uw *UnitWriter) AppUnit(ra *schema.RuntimeApp, binPath string, opts ...*un
 		unit.NewUnitOption("Unit", "DefaultDependencies", "false"),
 		unit.NewUnitOption("Unit", "Before", "halt.target"),
 		unit.NewUnitOption("Unit", "Conflicts", "halt.target"),
+		unit.NewUnitOption("Unit", "After", "shutdown.service"),
+		unit.NewUnitOption("Unit", "After", "systemd-journald.service"),
 		unit.NewUnitOption("Unit", "Wants", fmt.Sprintf("reaper-%s.service", appName)),
 		unit.NewUnitOption("Unit", "After", fmt.Sprintf("reaper-%s.service", appName)),
-		unit.NewUnitOption("Unit", "After", "shutdown.service"),
 		unit.NewUnitOption("Service", "Restart", "no"),
 
 		// This helps working around a race

--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -464,7 +464,11 @@ func (uw *UnitWriter) AppUnit(ra *schema.RuntimeApp, binPath string, opts ...*un
 	opts = append(opts, []*unit.UnitOption{
 		unit.NewUnitOption("Unit", "Description", fmt.Sprintf("Application=%v Image=%v", appName, imgName)),
 		unit.NewUnitOption("Unit", "DefaultDependencies", "false"),
+		unit.NewUnitOption("Unit", "Before", "halt.target"),
+		unit.NewUnitOption("Unit", "Conflicts", "halt.target"),
 		unit.NewUnitOption("Unit", "Wants", fmt.Sprintf("reaper-%s.service", appName)),
+		unit.NewUnitOption("Unit", "After", fmt.Sprintf("reaper-%s.service", appName)),
+		unit.NewUnitOption("Unit", "After", "shutdown.service"),
 		unit.NewUnitOption("Service", "Restart", "no"),
 
 		// This helps working around a race

--- a/tests/rkt_stop_test.go
+++ b/tests/rkt_stop_test.go
@@ -117,14 +117,68 @@ func TestRktStop(t *testing.T) {
 	}
 }
 
-func TestGracefulShutdown(t *testing.T) {
+func TestRktStopGracefulShutdown(t *testing.T) {
 	image := patchTestACI("rkt-stop-test.aci", "--name=rkt-stop-test", "--exec=/inspect --read-stdin --capture-signals")
 	defer os.Remove(image)
 
 	ctx := testutils.NewRktRunCtx()
 	defer ctx.Cleanup()
 
-	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), image)
+	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s --kill-timeout=2s", ctx.Cmd(), image)
+	podUUID := runRktAndGetUUID(t, cmd)
+
+	// Run image
+	cmd = fmt.Sprintf("%s --insecure-options=image run-prepared --interactive %s", ctx.Cmd(), podUUID)
+	child := spawnOrFail(t, cmd)
+
+	// Wait for prompt to make sure the pod is started
+	if err := expectTimeoutWithOutput(child, "Enter text:", time.Minute); err != nil {
+		t.Fatalf("Can't start pod")
+	}
+
+	// Issue stop command, and wait for it to complete
+	spawnAndWaitOrFail(t, fmt.Sprintf("%s stop %s", ctx.Cmd(), podUUID), 0)
+
+	expectTimeoutWithOutput(child, "Received: SIGTERM", 10*time.Second)
+	// Make sure it eventually gets SIGKILLed
+	waitOrFail(t, child, -1)
+}
+
+func TestRktStopAllGracefulShutdown(t *testing.T) {
+	image := patchTestACI("rkt-stop-test.aci", "--name=rkt-stop-test", "--exec=/inspect --read-stdin --capture-signals")
+	defer os.Remove(image)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s --kill-timeout=2s --kill-mode=all", ctx.Cmd(), image)
+	podUUID := runRktAndGetUUID(t, cmd)
+
+	// Run image
+	cmd = fmt.Sprintf("%s --insecure-options=image run-prepared --interactive %s", ctx.Cmd(), podUUID)
+	child := spawnOrFail(t, cmd)
+
+	// Wait for prompt to make sure the pod is started
+	if err := expectTimeoutWithOutput(child, "Enter text:", time.Minute); err != nil {
+		t.Fatalf("Can't start pod")
+	}
+
+	// Issue stop command, and wait for it to complete
+	spawnAndWaitOrFail(t, fmt.Sprintf("%s stop %s", ctx.Cmd(), podUUID), 0)
+
+	expectTimeoutWithOutput(child, "Received: SIGTERM", 10*time.Second)
+	// Make sure it eventually gets SIGKILLed
+	waitOrFail(t, child, -1)
+}
+
+func TestRktStopExecProcessGracefulShutdown(t *testing.T) {
+	image := patchTestACI("rkt-stop-test.aci", "--name=rkt-stop-test", "--exec=/inspect --read-stdin --capture-signals")
+	defer os.Remove(image)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s --kill-timeout=2s --kill-mode=leader", ctx.Cmd(), image)
 	podUUID := runRktAndGetUUID(t, cmd)
 
 	// Run image


### PR DESCRIPTION
These changes allow apps to capture `SIGTERM` signals and initiate graceful shutdown. New stage0 flags were added to control the behavior on stage1 flavor using systemd.

I only tested this on immutable apps, but it should work for mutable apps as well.

There are two available `--kill-mode` values:

* `all`: `SIGTERM` is sent to all processes in the app/image, then a `SIGKILL` to remaining processes after a timeout (90s by default, configurable with `--kill-timeout`). This translates to `KillMode=control-group` form `systemd.kill(5)`.
* `leader`: `SIGTERM` is only sent to the `--exec` process in the app/image, then a `SIGKILL` to remaining processes after a timeout (90s by default, configurable with `--kill-timeout`). This translates to `KillMode=mixed` from `systemd.kill(5)`, and is useful when a supervisor that will forward signals and control shutdown is running inside the app.