### PR TITLE
release 1.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.28.1
+
+This is a minor bugfix release. It does not contain any changes to the rkt code, but it updates dependencies and runtime versions for bugfixes:
+
+- vendor: update go-systemd to v15 ([#3759](https://github.com/rkt/rkt/pull/3759)). rkt stopped working when running in a service with systemd v234. This update fixes it.
+- scripts: update rkt-builder version to 1.3.0 ([#3754](https://github.com/rkt/rkt/pull/3754)). This updates the default Go runtime to 1.8, fixing [#3738](https://github.com/rkt/rkt/issues/3738).
+
+
 ## 1.28.0
 
 This release contains changes to the behavior of `rkt run`, `rkt status`, and `rkt fly` to make them more consistent. Two of them need particular attention:

--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -141,19 +141,19 @@ upgrade manually.
 ### rpm-based 
 ```
 gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-wget https://github.com/rkt/rkt/releases/download/v1.28.0/rkt-1.28.0-1.x86_64.rpm
-wget https://github.com/rkt/rkt/releases/download/v1.28.0/rkt-1.28.0-1.x86_64.rpm.asc
-gpg --verify rkt-1.28.0-1.x86_64.rpm.asc
-sudo rpm -Uvh rkt-1.28.0-1.x86_64.rpm
+wget https://github.com/rkt/rkt/releases/download/v1.28.1/rkt-1.28.1-1.x86_64.rpm
+wget https://github.com/rkt/rkt/releases/download/v1.28.1/rkt-1.28.1-1.x86_64.rpm.asc
+gpg --verify rkt-1.28.1-1.x86_64.rpm.asc
+sudo rpm -Uvh rkt-1.28.1-1.x86_64.rpm
 ```
 
 ### deb-based
 ```
 gpg --recv-key 18AD5014C99EF7E3BA5F6CE950BDD3E0FC8A365E
-wget https://github.com/rkt/rkt/releases/download/v1.28.0/rkt_1.28.0-1_amd64.deb
-wget https://github.com/rkt/rkt/releases/download/v1.28.0/rkt_1.28.0-1_amd64.deb.asc
-gpg --verify rkt_1.28.0-1_amd64.deb.asc
-sudo dpkg -i rkt_1.28.0-1_amd64.deb
+wget https://github.com/rkt/rkt/releases/download/v1.28.1/rkt_1.28.1-1_amd64.deb
+wget https://github.com/rkt/rkt/releases/download/v1.28.1/rkt_1.28.1-1_amd64.deb.asc
+gpg --verify rkt_1.28.1-1_amd64.deb.asc
+sudo dpkg -i rkt_1.28.1-1_amd64.deb
 ```
 
 [cl-install-rkt]: install-rkt-in-coreos.md

--- a/Documentation/proposals/oci.md
+++ b/Documentation/proposals/oci.md
@@ -139,6 +139,6 @@ Backwards compatibility: Currently the biggest concern identified is backwards c
 [oci-algorithms]: https://github.com/opencontainers/image-spec/blob/v1.0.0-rc2/descriptor.md#algorithms
 [oci-image-layout]: https://github.com/opencontainers/image-spec/blob/v1.0.0-rc2/image-layout.md
 
-[app-container]: https://github.com/rkt/rkt/blob/v1.28.0/Documentation/app-container.md
-[image-lifecycle]: https://github.com/rkt/rkt/blob/v1.28.0/Documentation/devel/architecture.md#image-lifecycle
-[distribution-point]: https://github.com/rkt/rkt/blob/v1.28.0/Documentation/devel/distribution-point.md
+[app-container]: https://github.com/rkt/rkt/blob/v1.28.1/Documentation/app-container.md
+[image-lifecycle]: https://github.com/rkt/rkt/blob/v1.28.1/Documentation/devel/architecture.md#image-lifecycle
+[distribution-point]: https://github.com/rkt/rkt/blob/v1.28.1/Documentation/devel/distribution-point.md

--- a/Documentation/running-fly-stage1.md
+++ b/Documentation/running-fly-stage1.md
@@ -60,14 +60,14 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=fly && make
 ```
 
 For more details about configure parameters, see the [configure script parameters documentation][build-configure].
-This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.28.0+git/bin/`.
+This will build the rkt binary and the stage1-fly.aci in `build-rkt-1.28.1+git/bin/`.
 
 ### Selecting stage1 at runtime
 
 Here is a quick example of how to use a container with the official fly stage1:
 
 ```
-# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.28.0 coreos.com/etcd:v2.2.5
+# rkt run --stage1-name=coreos.com/rkt/stage1-fly:1.28.1 coreos.com/etcd:v2.2.5
 ```
 
 If the image is not in the store, `--stage1-name` will perform discovery and fetch the image.

--- a/Documentation/running-kvm-stage1.md
+++ b/Documentation/running-kvm-stage1.md
@@ -9,7 +9,7 @@ The KVM stage1 does not yet implement all of the default stage1's features and s
 Provided you have hardware virtualization support and the [kernel KVM module][kvm-module] loaded (refer to your distribution for instructions), you can then run an image like you would normally do with rkt:
 
 ```
-sudo rkt run --debug --insecure-options=image --stage1-name=coreos.com/rkt/stage1-kvm:1.28.0 docker://redis
+sudo rkt run --debug --insecure-options=image --stage1-name=coreos.com/rkt/stage1-kvm:1.28.1 docker://redis
 ```
 
 This output is the same you'll get if you run a container-based rkt.
@@ -67,7 +67,7 @@ $ ./autogen.sh && ./configure --with-stage1-flavors=kvm --with-stage1-kvm-hyperv
 ```
 
 For more details about configure parameters, see [configure script parameters documentation][build-configure].
-This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.28.0+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
+This will build the rkt binary and the KVM stage1 aci image in `build-rkt-1.28.1+git/target/bin/`. Depending on the configuration options, it will be `stage1-kvm.aci` (if one hypervisor is set), or `stage1-kvm-lkvm.aci` and `stage1-kvm-qemu.aci` (if you want to have both images built once).
 
 
 [build-configure]: build-configure.md
@@ -89,7 +89,7 @@ Additional [Linux kernel's command line parameters](https://www.kernel.org/doc/h
 
 ```
 sudo RKT_HYPERVISOR_EXTRA_KERNEL_PARAMS="systemd.unified_cgroup_hierarchy=true max_loop=12 possible_cpus=1" \
-      rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.28.0 \
+      rkt run --stage1-name=coreos.com/rkt/stage1-kvm:1.28.1 \
       ...
 ```
 

--- a/Documentation/subcommands/prepare.md
+++ b/Documentation/subcommands/prepare.md
@@ -8,7 +8,7 @@ Support for overlay fs will be auto-detected if `--no-overlay` is set to `false`
 
 ```
 # rkt prepare --insecure-options=image docker://busybox --exec=/bin/sh
-image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.28.0
+image: using image from local store for image name coreos.com/rkt/stage1-coreos:1.28.1
 image: remote fetching from URL "docker://busybox"
 Downloading sha256:8ddc19f1652 [===============================] 668 KB / 668 KB
 prepare: disabling overlay support: "unsupported filesystem: missing d_type support"
@@ -32,7 +32,7 @@ Therefore, the supported arguments are mostly the same as in `run` except runtim
 ```
 # rkt prepare coreos.com/etcd:v2.0.10
 rkt prepare coreos.com/etcd:v2.0.10
-rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.28.0
+rkt: using image from local store for image name coreos.com/rkt/stage1-coreos:1.28.1
 rkt: searching for app image coreos.com/etcd:v2.0.10
 rkt: remote fetching from url https://github.com/coreos/etcd/releases/download/v2.0.10/etcd-v2.0.10-linux-amd64.aci
 prefix: "coreos.com/etcd"

--- a/Documentation/subcommands/version.md
+++ b/Documentation/subcommands/version.md
@@ -6,7 +6,7 @@ This command prints the rkt version, the appc version rkt is built against, and 
 
 ```
 $ rkt version
-rkt Version: 1.28.0
+rkt Version: 1.28.1
 appc Version: 0.8.10
 Go Version: go1.5.3
 Go OS/Arch: linux/amd64

--- a/Documentation/trying-out-rkt.md
+++ b/Documentation/trying-out-rkt.md
@@ -20,9 +20,9 @@ rkt is written in Go and can be compiled for several CPU architectures. The rkt 
 To start running the latest version of rkt on amd64, grab the release directly from the rkt GitHub project:
 
 ```
-wget https://github.com/rkt/rkt/releases/download/v1.28.0/rkt-v1.28.0.tar.gz
-tar xzvf rkt-v1.28.0.tar.gz
-cd rkt-v1.28.0
+wget https://github.com/rkt/rkt/releases/download/v1.28.1/rkt-v1.28.1.tar.gz
+tar xzvf rkt-v1.28.1.tar.gz
+cd rkt-v1.28.1
 ./rkt help
 ```
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.28.1], [https://github.com/rkt/rkt/issues])
+AC_INIT([rkt], [1.28.1+git], [https://github.com/rkt/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.63])
-AC_INIT([rkt], [1.28.0+git], [https://github.com/rkt/rkt/issues])
+AC_INIT([rkt], [1.28.1], [https://github.com/rkt/rkt/issues])
 
 AC_PROG_CC
 AC_PROG_CXX

--- a/scripts/install-rkt.sh
+++ b/scripts/install-rkt.sh
@@ -4,7 +4,7 @@ set -x
 
 cd $(mktemp -d)
 
-version="1.28.0"
+version="1.28.1"
 
 export DEBIAN_FRONTEND=noninteractive
 

--- a/tests/empty-image/manifest
+++ b/tests/empty-image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.28.0"
+            "value": "1.28.1"
         },
         {
             "name": "arch",

--- a/tests/image/manifest
+++ b/tests/image/manifest
@@ -5,7 +5,7 @@
     "labels": [
         {
             "name": "version",
-            "value": "1.28.0"
+            "value": "1.28.1"
         },
         {
             "name": "arch",

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.28.1/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.28.1+git/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt-monitor/build-stresser.sh
+++ b/tests/rkt-monitor/build-stresser.sh
@@ -27,7 +27,7 @@ buildImages() {
     acbuild --debug begin
     trap acbuildEnd EXIT
     acbuild --debug set-name appc.io/rkt-"${1}"-stresser
-    acbuild --debug copy build-rkt-1.28.0+git/target/bin/"${1}"-stresser /worker
+    acbuild --debug copy build-rkt-1.28.1/target/bin/"${1}"-stresser /worker
     acbuild --debug set-exec -- /worker
     acbuild --debug write --overwrite "${1}"-stresser.aci
     acbuild --debug end

--- a/tests/rkt_exec_test.go
+++ b/tests/rkt_exec_test.go
@@ -36,7 +36,7 @@ func TestRunOverrideExec(t *testing.T) {
 	noappManifest := schema.ImageManifest{
 		Name: "coreos.com/rkt-inspect",
 		Labels: types.Labels{
-			{"version", "1.28.0"},
+			{"version", "1.28.1"},
 			{"arch", common.GetArch()},
 			{"os", common.GetOS()},
 		},

--- a/tests/rkt_image_cat_manifest_test.go
+++ b/tests/rkt_image_cat_manifest_test.go
@@ -47,7 +47,7 @@ func TestImageCatManifest(t *testing.T) {
 			},
 		},
 		Labels: types.Labels{
-			{"version", "1.28.0"},
+			{"version", "1.28.1"},
 			{"arch", common.GetArch()},
 			{"os", common.GetOS()},
 		},

--- a/tests/rkt_image_export_test.go
+++ b/tests/rkt_image_export_test.go
@@ -46,7 +46,7 @@ func TestImageExport(t *testing.T) {
 			},
 		},
 		Labels: types.Labels{
-			{"version", "1.28.0"},
+			{"version", "1.28.1"},
 			{"arch", common.GetArch()},
 			{"os", common.GetOS()},
 		},

--- a/tests/rkt_image_render_test.go
+++ b/tests/rkt_image_render_test.go
@@ -56,7 +56,7 @@ func TestImageRender(t *testing.T) {
 			{ImageName: "coreos.com/rkt-inspect"},
 		},
 		Labels: types.Labels{
-			{"version", "1.28.0"},
+			{"version", "1.28.1"},
 			{"arch", common.GetArch()},
 			{"os", common.GetOS()},
 		},

--- a/tests/rkt_os_arch_test.go
+++ b/tests/rkt_os_arch_test.go
@@ -61,7 +61,7 @@ func getMissingOrInvalidTests(t *testing.T, ctx *testutils.RktRunCtx) []osArchTe
 			WorkingDirectory: "/",
 		},
 		Labels: types.Labels{
-			{"version", "1.28.0"},
+			{"version", "1.28.1"},
 		},
 	}
 


### PR DESCRIPTION
This is a minor bugfix release. It does not contain any changes to the rkt code, but it updates depencies and runtime versions for bugfixes:

 - vendor: update go-systemd to v15 ([#3759](https://github.com/rkt/rkt/pull/3759)). rkt stopped working when running in a service with systemd v234. This update fixes it.
 - scripts: update rkt-builder version to 1.3.0 ([#3754](https://github.com/rkt/rkt/pull/3754)). This updates the default Go runtime to 1.8, fixing https://github.com/rkt/rkt/issues/3738.