### PR TITLE
networking: ensure the netns directory is mounted

### DIFF
--- a/networking/networking.go
+++ b/networking/networking.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	IfNamePattern = "eth%d"
-	selfNetNS     = "/proc/self/ns/net"
+	IfNamePattern       = "eth%d"
+	selfNetNS           = "/proc/self/ns/net"
+	mountNetnsDirectory = "/var/run/netns"
 )
 
 // Networking describes the networking details of a pod.
@@ -83,8 +84,13 @@ func Setup(podRoot string, podID types.UUID, fps []commonnet.ForwardedPort, netL
 		},
 	}
 
+	err := n.mountNetnsDirectory()
+	if err != nil {
+		return nil, err
+	}
+
 	// Create the network namespace (and save its name in a file)
-	err := n.podNSCreate()
+	err = n.podNSCreate()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Context
Coming from Kubernetes issue [48427](https://github.com/kubernetes/kubernetes/issues/48427).
Initially I was thinking of doing it in the kubelet rkt code but as @squeed suggested, it's simpler and less hacky to do it in rkt codebase.

### TL;DR:
This PR ensure the `/run/netns` directory is always mounted once as tmpfs.
The `ip netns add <some-id>` command has this behavior by default. The kubelet calls this command for every new `hostNetwork: false` pods.

A mount of `/run/netns` over any existing netns files like `/run/netns/cni-30b37e42-157e-9796-dd74-ba4a3689bbde` cause issues with them.

### Warning
Upgrading rkt with this fix needs a full drain of any running rkt-netns containers on the node.