### PR TITLE
stage1: support hybrid cgroup hierarchy

### DIFF
--- a/common/cgroup/v1/cgroup.go
+++ b/common/cgroup/v1/cgroup.go
@@ -316,6 +316,11 @@ func CreateCgroups(m fs.Mounter, root string, enabledCgroups map[int][]string, m
 		return err
 	}
 
+	unifiedPath := filepath.Join(root, "/sys/fs/cgroup/unified")
+	if err := os.MkdirAll(unifiedPath, 0700); err != nil {
+		return err
+	}
+
 	// Bind-mount cgroup tmpfs filesystem read-only
 	return mountFsRO(m, cgroupTmpfs, cgroupTmpfsFlags)
 }


### PR DESCRIPTION
systemd introduced the hybrid cgroup hierarchy that mounts a cgroup v1
and v2 hierarchy in parallel. After systemd v233 the cgroup v2 hierarchy
is mounted in `/sys/fs/cgroup/unified`. This breaks rkt (specifically
flavor host) because we mount `/sys/fs/cgroup` ourselves and were not
creating the `unified` directory.

Let's create `/sys/fs/cgroup/unified` in `CreateCgroup()` to support the
hybrid cgroup hierarchy. If the host system (or the stage1) doesn't use
the hybrid hierarchy, having this directory created doesn't hurt.

Fixes #3741 