### PR TITLE
lib/app: check in upper/ if the pod uses overlay

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -125,14 +125,26 @@ func PodManifestLockPath(root string) string {
 	return filepath.Join(root, "pod.lck")
 }
 
+// AppsStatusesPathFromStage1Rootfs returns the path of the status dir for all apps.
+// It receives the stage1 rootfs as parameter instead of the pod root.
+func AppsStatusesPathFromStage1Rootfs(rootfs string) string {
+	return filepath.Join(rootfs, "/rkt/status")
+}
+
 // AppsStatusesPath returns the path of the status dir for all apps.
 func AppsStatusesPath(root string) string {
-	return filepath.Join(Stage1RootfsPath(root), "/rkt/status")
+	return AppsStatusesPathFromStage1Rootfs(Stage1RootfsPath(root))
 }
 
 // AppStatusPath returns the path of the status file of an app.
 func AppStatusPath(root, appName string) string {
 	return filepath.Join(AppsStatusesPath(root), appName)
+}
+
+// AppStatusPathFromStage1Rootfs returns the path of the status file of an app.
+// It receives the stage1 rootfs as parameter instead of the pod root.
+func AppStatusPathFromStage1Rootfs(rootfs, appName string) string {
+	return filepath.Join(AppsStatusesPathFromStage1Rootfs(rootfs), appName)
 }
 
 // AppCreatedPath returns the path of the ${appname}-created file, which is used to record
@@ -141,10 +153,24 @@ func AppCreatedPath(root, appName string) string {
 	return filepath.Join(AppsStatusesPath(root), fmt.Sprintf("%s-created", appName))
 }
 
+// AppCreatedPathFromStage1Rootfs returns the path of the ${appname}-created file,
+// which is used to record the creation timestamp of the app.
+// It receives the stage1 rootfs as parameter instead of the pod root.
+func AppCreatedPathFromStage1Rootfs(rootfs, appName string) string {
+	return filepath.Join(AppsStatusesPathFromStage1Rootfs(rootfs), fmt.Sprintf("%s-created", appName))
+}
+
 // AppStartedPath returns the path of the ${appname}-started file, which is used to record
 // the start timestamp of the app.
 func AppStartedPath(root, appName string) string {
 	return filepath.Join(AppsStatusesPath(root), fmt.Sprintf("%s-started", appName))
+}
+
+// AppStartedPathFromStage1Rootfs returns the path of the ${appname}-started file, which is used to record
+// the start timestamp of the app.
+// It receives the stage1 rootfs as parameter instead of the pod root.
+func AppStartedPathFromStage1Rootfs(rootfs, appName string) string {
+	return filepath.Join(AppsStatusesPathFromStage1Rootfs(rootfs), fmt.Sprintf("%s-started", appName))
 }
 
 // AppsPath returns the path where the apps within a pod live.

--- a/lib/app.go
+++ b/lib/app.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/appc/spec/schema"
 	"github.com/appc/spec/schema/types"
@@ -137,23 +136,14 @@ func appStateInMutablePod(app *v1.App, pod *pkgPod.Pod) error {
 			}
 		}
 	}()
-	createdFile := common.AppCreatedPath(pod.Path(), app.Name)
-	startedFile := common.AppStartedPath(pod.Path(), app.Name)
-	appStatusFile := common.AppStatusPath(pod.Path(), app.Name)
 
-	if pod.UsesOverlay() {
-		treeStoreID, err := pod.GetStage1TreeStoreID()
-		if err != nil {
-			return err
-		}
-		s1Dir := filepath.Join(filepath.Join(pod.Path(), "overlay"), treeStoreID)
-		upper := filepath.Join(s1Dir, "upper")
-		appStatusesPath := filepath.Join(upper, "/rkt/status")
-
-		createdFile = filepath.Join(appStatusesPath, fmt.Sprintf("%s-created", app.Name))
-		startedFile = filepath.Join(appStatusesPath, fmt.Sprintf("%s-started", app.Name))
-		appStatusFile = filepath.Join(appStatusesPath, app.Name)
+	stage1RootfsPath, err := pod.Stage1RootfsPath()
+	if err != nil {
+		return err
 	}
+	createdFile := common.AppCreatedPathFromStage1Rootfs(stage1RootfsPath, app.Name)
+	startedFile := common.AppStartedPathFromStage1Rootfs(stage1RootfsPath, app.Name)
+	appStatusFile := common.AppStatusPathFromStage1Rootfs(stage1RootfsPath, app.Name)
 
 	// Check if the app is created.
 	fi, err := os.Stat(createdFile)

--- a/pkg/pod/pods.go
+++ b/pkg/pod/pods.go
@@ -1208,7 +1208,7 @@ func (p *Pod) AppExitCode(appName string) (int, error) {
 		return -1, err
 	}
 
-	statusFile := filepath.Join(stage1RootfsPath, "/rkt/status/", appName)
+	statusFile := common.AppStatusPathFromStage1Rootfs(stage1RootfsPath, appName)
 	return p.readIntFromFile(statusFile)
 }
 

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -43,9 +43,8 @@ They can also be set to a duration. If the duration is less than zero, wait inde
 )
 
 const (
-	overlayStatusDirTemplate = "overlay/%s/upper/rkt/status"
-	regularStatusDir         = "stage1/rootfs/rkt/status"
-	cmdStatusName            = "status"
+	regularStatusDir = "stage1/rootfs/rkt/status"
+	cmdStatusName    = "status"
 )
 
 func init() {

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -870,8 +870,7 @@ func setupStage1Image(cfg RunConfig, cdir string, useOverlay bool) error {
 			return err
 		}
 
-		// pass an empty appName: make sure it remains consistent with
-		// overlayStatusDirTemplate
+		// pass an empty appName
 		if err := overlayRender(cfg, string(treeStoreID), cdir, s1, ""); err != nil {
 			return errwrap.Wrap(errors.New("error rendering overlay filesystem"), err)
 		}


### PR DESCRIPTION
Getting creation/start time and status of applications will fail for
pods using overlay if stage1 was unmounted (e.g. when rebooting).

This commit checks in the `upper/` directory if the pod uses overlay.