### PR TITLE
image: set the header instead of adding it

### DIFF
--- a/rkt/image/resumablesession.go
+++ b/rkt/image/resumablesession.go
@@ -361,7 +361,7 @@ func (s *resumableSession) setHTTPHeaders(req *http.Request, stripAuth bool) {
 			continue
 		}
 		for _, e := range v {
-			req.Header.Add(k, e)
+			req.Header.Set(k, e)
 		}
 	}
 	req.Header.Add("User-Agent", fmt.Sprintf("rkt/%s", version.Version))


### PR DESCRIPTION
The go [http/client](https://golang.org/doc/go1.8#net_http) changes its behavior for redirect and header's copy since the go 1.8:

> The Client now copies most request headers on redirect.

The ETag header is added and sent twice in the http header request as mentioned in #3678.
This behavior was tracked by ARCH users because they bumped to go1.8 earlier.

As the last release (github v1.28.1) bumped to go1.8, the problem is now present globally.
