### PR TITLE
api: add CreatedAt to v1.Pod

### DIFF
--- a/api/v1/json.go
+++ b/api/v1/json.go
@@ -77,6 +77,8 @@ type (
 		AppNames []string `json:"app_names,omitempty"`
 		// Apps holds current information about each app.
 		Apps []*App `json:"apps,omitempty"`
+		// The creation time of the pod.
+		CreatedAt *int64 `json:"created_at,omitempty"`
 		// The start time of the pod.
 		StartedAt *int64 `json:"started_at,omitempty"`
 		// UserAnnotations are the pod user annotations.

--- a/lib/pod.go
+++ b/lib/pod.go
@@ -15,6 +15,8 @@
 package rkt
 
 import (
+	"errors"
+
 	"github.com/rkt/rkt/api/v1"
 	pkgPod "github.com/rkt/rkt/pkg/pod"
 )
@@ -36,6 +38,17 @@ func NewPodFromInternalPod(p *pkgPod.Pod) (*v1.Pod, error) {
 		startedAt := startTime.Unix()
 		pod.StartedAt = &startedAt
 	}
+
+	creationTime, err := p.CreationTime()
+	if err != nil {
+		return nil, err
+	}
+
+	createdAt := creationTime.Unix()
+	if creationTime.IsZero() || createdAt <= 0 {
+		return nil, errors.New("invalid creation time")
+	}
+	pod.CreatedAt = &createdAt
 
 	if !p.PodManifestAvailable() {
 		return pod, nil

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -673,6 +673,14 @@ func parsePodInfoOutput(t *testing.T, result string, p *podInfo) {
 			}
 		}
 	}
+
+	if p.state == "" {
+		t.Fatalf("Unexpected empty state for pod")
+	}
+
+	if p.createdAt <= 0 {
+		t.Fatalf("Unexpected createdAt <= 0 for pod")
+	}
 }
 
 func getPodDir(t *testing.T, ctx *testutils.RktRunCtx, podID string) string {


### PR DESCRIPTION
It might happen that the pod is created but we can't get its start time
(e.g. we can't find the CNI network corresponding to `--net=NETWORK`).

This means StartedAt will not be set and the kubelet will error out and
ignore the pod, so it won't try to start it again.

Let's introduce CreatedAt to express the time when the pod was created
(even if it doesn't start) to handle this. This works because this time
is available after pod preparation.

We'll need to change rktlet to use CreatedAt instead of StartedAt when
getting a pod sandbox status.