### PR TITLE
iottymux: Store logs for kubelet in the appropriate location

### DIFF
--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -328,6 +328,16 @@ func (uw *UnitWriter) SetupAppIO(p *stage1commontypes.Pod, ra *schema.RuntimeApp
 			if ok {
 				file.WriteString(fmt.Sprintf("STAGE1_LOGMODE=%s\n", logMode))
 			}
+			switch logMode {
+			case "k8s-plain":
+				kubernetesLogPath, ok := ra.Annotations.Get("coreos.com/rkt/experiment/kubernetes-log-path")
+				if !ok {
+					uw.err = fmt.Errorf("kubernetes-log-path annotation needs to be specified when k8s-plain logging mode is used")
+					return nil
+				}
+				file.WriteString(fmt.Sprintf("KUBERNETES_LOG_PATH=%s\n", kubernetesLogPath))
+			}
+
 		} else if needsTTYMux {
 			// tty mode brings in a `ttymux@.service` after-dependency (it needs to create the TTY first)
 			opts = append(opts, unit.NewUnitOption("Service", "TTYPath", filepath.Join("/rkt/iottymux", ra.Name.String(), "stage2-pts")))

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -362,6 +362,11 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, canMachinedRegister boo
 			args = append(args, fmt.Sprintf("--register=false"))
 		}
 
+		kubernetesLogDir, ok := p.Manifest.Annotations.Get("coreos.com/rkt/experiment/kubernetes-log-dir")
+		if ok {
+			args = append(args, fmt.Sprintf("--bind=%s:/rkt/kubernetes/log", kubernetesLogDir))
+		}
+
 		// use only dynamic libraries provided in the image
 		// from systemd v231 there's a new internal libsystemd-shared-v231.so
 		// which is present in /usr/lib/systemd


### PR DESCRIPTION
This is the change made for rktlet. Kubelet expect the CRI-formatted
logs to be in specific directory and it provides that information with
CRI.

CRI-compatible logs are generated by iottymux. That specific directory
which kubelet is looking at, exists in the host filesystem. In order to
make it available for iottymux, we need to mount it into the stage1
container. That's why this commit introduces the new annotation called
coreos.com/rkt/experiment/kubernetes-log-dir. This annotation is read
by stage1 init and the directory by it is bind mounted to the stage1
nspawn container (the mountpoint inside container is /rkt/kubernetes/log).

Kubelet provides the name of a logfile of a container via CRI. Since the
container concept in Kubernetes refers to an app in rkt, we use the
annotation named coreos.com/rkt/experiment/kubernetes-log-path to pass it
from rktlet. Then stage1 init redirects that value in KUBERNETES_LOG_PATH
environment variable for iottymux.

Then finally, iottymux saves the logs to /rkt/kubernetes/log/$KUBERNETES_LOG_PATH
file, i.e. /rkt/kubernetes/log/0a8f619b-df34-4c57-86e5-84a551452db1/etcd_0.log.

Fixes #3795