### PR TITLE
stage0,rkt: don't require the pod to be running to remove apps

### DIFF
--- a/pkg/pod/sandbox.go
+++ b/pkg/pod/sandbox.go
@@ -94,12 +94,8 @@ func (p *Pod) UpdateManifest(m *schema.PodManifest, path string) error {
 }
 
 // ExclusiveLockManifest gets an exclusive lock on only the pod manifest in the app sandbox.
-// Since the pod is already running, we won't be able to get an exclusive lock on the pod itself.
+// Since the pod might already be running, we can't just get an exclusive lock on the pod itself.
 func (p *Pod) ExclusiveLockManifest() error {
-	if !p.isRunning() {
-		return errors.New("pod is not running")
-	}
-
 	if p.manifestLock != nil {
 		return p.manifestLock.ExclusiveLock() // This is idempotent
 	}
@@ -115,10 +111,6 @@ func (p *Pod) ExclusiveLockManifest() error {
 
 // UnlockManifest unlocks the pod manifest lock.
 func (p *Pod) UnlockManifest() error {
-	if !p.isRunning() {
-		return errors.New("pod is not running")
-	}
-
 	if p.manifestLock == nil {
 		return nil
 	}

--- a/stage0/app_add.go
+++ b/stage0/app_add.go
@@ -74,6 +74,10 @@ func AddApp(cfg AddConfig) error {
 	}
 	defer pod.Close()
 
+	if pod.State() != pkgPod.Running {
+		return errors.New("pod is not running")
+	}
+
 	debug("locking pod manifest")
 	if err := pod.ExclusiveLockManifest(); err != nil {
 		return errwrap.Wrap(errors.New("failed to lock pod manifest"), err)


### PR DESCRIPTION
The kubelet tries to remove apps from pods that are stopped and there's
no reason to prevent the removal of apps from not running pods, actually
it was considered in some parts of stage0.RmApp().

Let's not require pods to be running to remove apps. If the pod is
running, we'll still stop the app units and so on. If not, we just
remove the app.