### PR TITLE
app/add: Use the image name as a default name for app

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -539,3 +539,17 @@ func GetOSArch() (os string, arch string) {
 	os, arch, _ = types.ToAppcOSArch(runtime.GOOS, arch, flavor)
 	return os, arch
 }
+
+// ImageNameToAppName converts the full name of image to an app name without special
+// characters - we use it as a default app name when specyfing it is optional
+func ImageNameToAppName(name types.ACIdentifier) (*types.ACName, error) {
+	parts := strings.Split(name.String(), "/")
+	last := parts[len(parts)-1]
+
+	sn, err := types.SanitizeACName(last)
+	if err != nil {
+		return nil, err
+	}
+
+	return types.MustACName(sn), nil
+}

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,0 +1,56 @@
+// Copyright 2017 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/appc/spec/schema/types"
+)
+
+func TestImageNameToAppName(t *testing.T) {
+	for _, tt := range []struct {
+		in  types.ACIdentifier
+		out types.ACName
+		err bool
+	}{
+		{
+			in:  types.ACIdentifier("coreos.com/etcd:v2.0.0"),
+			out: types.ACName("etcd-v2-0-0"),
+			err: false,
+		},
+		{
+			in:  types.ACIdentifier("coreos.com/etcd"),
+			out: types.ACName("etcd"),
+			err: false,
+		},
+		{
+			in:  types.ACIdentifier("docker://registry.hub.docker.com/library/fedora"),
+			out: types.ACName("fedora"),
+			err: false,
+		},
+	} {
+		appName, err := ImageNameToAppName(tt.in)
+		if err != nil {
+			if !tt.err {
+				t.Fatal(err)
+			}
+		} else if appName == nil {
+			t.Errorf("got nil app name without any error")
+		} else if *appName != tt.out {
+			t.Errorf("got %s app name, expected %s app name", appName, tt.out)
+		}
+	}
+}

--- a/stage0/app_add.go
+++ b/stage0/app_add.go
@@ -62,10 +62,11 @@ func AddApp(cfg AddConfig) error {
 			return err
 		}
 	} else {
-		appName, err = imageNameToAppName(am.Name)
+		appName, err = common.ImageNameToAppName(am.Name)
 		if err != nil {
 			return err
 		}
+		app.Name = appName.String()
 	}
 
 	pod, err := pkgPod.PodFromUUIDString(cfg.DataDir, cfg.UUID.String())

--- a/stage0/run.go
+++ b/stage0/run.go
@@ -156,18 +156,6 @@ func mergeEnvs(appEnv *types.Environment, env []string, override bool) {
 	}
 }
 
-func imageNameToAppName(name types.ACIdentifier) (*types.ACName, error) {
-	parts := strings.Split(name.String(), "/")
-	last := parts[len(parts)-1]
-
-	sn, err := types.SanitizeACName(last)
-	if err != nil {
-		return nil, err
-	}
-
-	return types.MustACName(sn), nil
-}
-
 // deduplicateMPs removes Mounts with duplicated paths. If there's more than
 // one Mount with the same path, it keeps the first one encountered.
 func deduplicateMPs(mounts []schema.Mount) []schema.Mount {
@@ -213,7 +201,7 @@ func generatePodManifest(cfg PrepareConfig, dir string) ([]byte, error) {
 		}
 
 		if app.Name == "" {
-			appName, err := imageNameToAppName(am.Name)
+			appName, err := common.ImageNameToAppName(am.Name)
 			if err != nil {
 				return errwrap.Wrap(errors.New("error converting image name to app name"), err)
 			}


### PR DESCRIPTION
The help message in "app add" sucommand suggests that --name flag is optional, but it wasn't. This commit fixes the desired behaviour.

Fixes #3801