### PR TITLE
stage1/init: activate systemd-journal-flush.service

### DIFF
--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -93,6 +93,8 @@ func MutableEnv(p *stage1commontypes.Pod) error {
 		unit.NewUnitOption("Service", "RemainAfterExit", "yes"),
 	)
 
+	w.Activate("systemd-journal-flush.service", ServiceWantPath(p.Root, "systemd-journal-flush"))
+
 	return w.Error()
 }
 
@@ -179,6 +181,8 @@ func ImmutableEnv(p *stage1commontypes.Pod) error {
 			unit.NewUnitOption("Unit", "After", "shutdown.service"),
 		)
 	}
+
+	uw.Activate("systemd-journal-flush.service", ServiceWantPath(p.Root, "systemd-journal-flush"))
 
 	return uw.Error()
 }


### PR DESCRIPTION
It's needed to make systemd-journald write to /var/log/journal instead
of /run/log/journal. We added this unit in 7c7e833e9 but we didn't configure it so it starts.