### PR TITLE
Sort stage1 manifest files

### DIFF
--- a/Documentation/devel/update-coreos-stage1.md
+++ b/Documentation/devel/update-coreos-stage1.md
@@ -80,6 +80,8 @@ done
 Usually, there are some updated libraries which need an update on their version numbers.
 In our case, there are no updates and all the files mentioned in the manifest are present in the updated Container Linux image.
 
+If any of the manifest files have been modified run the script `scripts/sort-stage1-manifests.sh` to keep the manifest files in sorted order.
+
 ## Update the coreos flavor version used by the build system
 
 In the file `stage1/usr_from_coreos/coreos-common.mk`, we define which Container Linux image version we use for the coreos flavor.

--- a/scripts/sort-stage1-manifests.sh
+++ b/scripts/sort-stage1-manifests.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Usage: [TOP_DIR=directory] sort-stage1-manifests.sh
+
+set -e
+
+: ${TOP_DIR:="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"}
+
+tmp=$(mktemp --tmpdir manifest-sort-XXX)
+
+cleanup () {
+	rm -f ${tmp}
+}
+
+trap cleanup EXIT
+
+boards='amd64-usr arm64-usr'
+flavors='usr_from_coreos usr_from_kvm'
+
+for board in ${boards}; do
+	for flavor in ${flavors}; do
+		dir="${TOP_DIR}/stage1/${flavor}/manifest-${board}.d/"
+		files=$(find ${dir} -type f -name '*.manifest')
+		for f in ${files}; do
+			cat ${f} | sort | uniq | sed '/^$/d' > ${tmp}
+			cp ${tmp} ${f}
+		done
+	done
+done

--- a/stage1/usr_from_kvm/manifest-amd64-usr.d/sshd.manifest
+++ b/stage1/usr_from_kvm/manifest-amd64-usr.d/sshd.manifest
@@ -4,8 +4,8 @@ bin/ssh-keygen
 lib64/libcom_err.so.2
 lib64/libcom_err.so.2.1
 lib64/libcrypt-2.23.so
-lib64/libcrypt.so.1
 lib64/libcrypto.so.1.0.0
+lib64/libcrypt.so.1
 lib64/libgssapi_krb5.so.2
 lib64/libgssapi_krb5.so.2.2
 lib64/libk5crypto.so.3

--- a/stage1/usr_from_kvm/manifest-arm64-usr.d/ip.manifest
+++ b/stage1/usr_from_kvm/manifest-arm64-usr.d/ip.manifest
@@ -1,8 +1,8 @@
 bin/ip
-lib64/libdl.so.2
-lib64/libdl-2.23.so
-lib64/libc.so.6
-lib64/libc-2.23.so
-lib64/ld-linux-aarch64.so.1
 lib64/ld-2.23.so
+lib64/ld-linux-aarch64.so.1
+lib64/libc-2.23.so
+lib64/libc.so.6
+lib64/libdl-2.23.so
+lib64/libdl.so.2
 lib/ld-linux-aarch64.so.1


### PR DESCRIPTION
To ease maintenance let's keep the stage1 manifest files sorted.  Adds a script `sort-stage1-manifests.sh`, and sorts the usr_from_kvm files.  The usr_from_coreos files were sorted in https://github.com/rkt/rkt/commit/e70889eea122e73afd94cc2598f87b4919328b30 (stage1: upgrade to systemd-v233 from CoreOS 1478.0.0).

cc: @alban 
