### PR TITLE
app/add: Allow to define annotations for app from CLI

### DIFF
--- a/common/apps/apps.go
+++ b/common/apps/apps.go
@@ -63,6 +63,7 @@ type App struct {
 	CapsRemove        *types.LinuxCapabilitiesRevokeSet // os/linux/capabilities-remove-set overrides
 	SeccompFilter     string                            // seccomp CLI overrides
 	OOMScoreAdj       *types.LinuxOOMScoreAdj           // oom-score-adj isolator override
+	Annotations       map[string]string                 // the annotations of the app
 	UserAnnotations   map[string]string                 // the user annotations of the app.
 	UserLabels        map[string]string                 // the user labels of the app.
 	Environments      map[string]string                 // the environments of the app.

--- a/rkt/app_sandbox.go
+++ b/rkt/app_sandbox.go
@@ -39,9 +39,9 @@ var (
 		Long:  "Initializes an empty pod having no applications.",
 		Run:   runWrapper(runAppSandbox),
 	}
-	flagAppPorts    appPortList
-	flagAnnotations kvMap
-	flagLabels      kvMap
+	flagAppPorts        appPortList
+	flagUserAnnotations kvMap
+	flagLabels          kvMap
 )
 
 func init() {
@@ -60,7 +60,7 @@ func init() {
 	cmdAppSandbox.Flags().Var(&flagAppPorts, "port", "ports to forward. format: \"name:proto:podPort:hostIP:hostPort\"")
 
 	flagAppPorts = appPortList{}
-	cmdAppSandbox.Flags().Var(&flagAnnotations, "user-annotation", "optional, set the pod's annotations in the form of key=value")
+	cmdAppSandbox.Flags().Var(&flagUserAnnotations, "user-annotation", "optional, set the pod's annotations in the form of key=value")
 	cmdAppSandbox.Flags().Var(&flagLabels, "user-label", "optional, set the pod's label in the form of key=value")
 }
 
@@ -140,7 +140,7 @@ func runAppSandbox(cmd *cobra.Command, args []string) int {
 		PrivateUsers:    user.NewBlankUidRange(),
 		Apps:            &rktApps,
 		Ports:           []types.ExposedPort(flagAppPorts),
-		UserAnnotations: parseAnnotations(&flagAnnotations),
+		UserAnnotations: parseAnnotations(&flagUserAnnotations),
 		UserLabels:      parseLabels(&flagLabels),
 	}
 
@@ -297,12 +297,12 @@ func (apl *appPortList) Type() string {
 
 // parseAnnotations converts the annotations set by '--user-annotation' flag,
 // and returns types.UserAnnotations.
-func parseAnnotations(flagAnnotations *kvMap) types.UserAnnotations {
-	if flagAnnotations.IsEmpty() {
+func parseAnnotations(flagUserAnnotations *kvMap) types.UserAnnotations {
+	if flagUserAnnotations.IsEmpty() {
 		return nil
 	}
 	annotations := make(types.UserAnnotations)
-	for k, v := range flagAnnotations.mapping {
+	for k, v := range flagUserAnnotations.mapping {
 		annotations[k] = v
 	}
 	return annotations

--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -600,10 +600,47 @@ func (au *appName) Type() string {
 	return "appName"
 }
 
-// appAnnotation is for --user-annotation flags in the form of: --user-annotation=NAME=VALUE.
+// appAnnotation is for --annotation flags in the form of: --annotation=name=value
 type appAnnotation apps.Apps
 
 func (au *appAnnotation) Set(s string) error {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return fmt.Errorf("--annotation must follow an image")
+	}
+
+	fields := strings.SplitN(s, "=", 2)
+	if len(fields) != 2 {
+		return fmt.Errorf("invalid format of --annotation flag %q", s)
+	}
+
+	if app.Annotations == nil {
+		app.Annotations = make(map[string]string)
+	}
+	app.Annotations[fields[0]] = fields[1]
+	return nil
+}
+
+func (au *appAnnotation) String() string {
+	app := (*apps.Apps)(au).Last()
+	if app == nil {
+		return ""
+	}
+	var annotations []string
+	for name, value := range app.Annotations {
+		annotations = append(annotations, fmt.Sprintf("%s=%s", name, value))
+	}
+	return strings.Join(annotations, ",")
+}
+
+func (au *appAnnotation) Type() string {
+	return "appAnnotation"
+}
+
+// appUserAnnotation is for --user-annotation flags in the form of: --user-annotation=NAME=VALUE.
+type appUserAnnotation apps.Apps
+
+func (au *appUserAnnotation) Set(s string) error {
 	app := (*apps.Apps)(au).Last()
 	if app == nil {
 		return fmt.Errorf("--user-annotation must follow an image")
@@ -621,7 +658,7 @@ func (au *appAnnotation) Set(s string) error {
 	return nil
 }
 
-func (au *appAnnotation) String() string {
+func (au *appUserAnnotation) String() string {
 	app := (*apps.Apps)(au).Last()
 	if app == nil {
 		return ""
@@ -633,8 +670,8 @@ func (au *appAnnotation) String() string {
 	return strings.Join(annotations, ",")
 }
 
-func (au *appAnnotation) Type() string {
-	return "appAnnotation"
+func (au *appUserAnnotation) Type() string {
+	return "appUserAnnotation"
 }
 
 // appLabel is for --user-label flags in the form of: --user-label=NAME=VALUE.

--- a/rkt/run.go
+++ b/rkt/run.go
@@ -108,7 +108,8 @@ func addAppFlags(cmd *cobra.Command) {
 	cmd.Flags().Var((*appGroup)(&rktApps), "group", "group override for the preceding image (example: '--group=group')")
 	cmd.Flags().Var((*appSupplementaryGIDs)(&rktApps), "supplementary-gids", "supplementary group IDs override for the preceding image (examples: '--supplementary-gids=1024,2048'")
 	cmd.Flags().Var((*appName)(&rktApps), "name", "set the name of the app (example: '--name=foo'). If not set, then the app name default to the image's name")
-	cmd.Flags().Var((*appAnnotation)(&rktApps), "user-annotation", "set the app's annotations (example: '--user-annotation=foo=bar')")
+	cmd.Flags().Var((*appAnnotation)(&rktApps), "annotation", "set the app's annotations (example: '--annotation=foo=bar')")
+	cmd.Flags().Var((*appUserAnnotation)(&rktApps), "user-annotation", "set the app's annotations (example: '--user-annotation=foo=bar')")
 	cmd.Flags().Var((*appLabel)(&rktApps), "user-label", "set the app's labels (example: '--user-label=foo=bar')")
 	cmd.Flags().Var((*appEnv)(&rktApps), "environment", "set the app's environment variables (example: '--environment=foo=bar')")
 	if common.IsExperimentEnabled("attach") {

--- a/stage0/common.go
+++ b/stage0/common.go
@@ -164,6 +164,18 @@ func generateRuntimeApp(appRunConfig *apps.App, am *schema.ImageManifest, podMou
 		ra.App.SupplementaryGIDs = appRunConfig.SupplementaryGIDs
 	}
 
+	for k, v := range appRunConfig.Annotations {
+		if _, ok := ra.Annotations.Get(k); ok {
+			continue
+		}
+		kAci, err := types.NewACIdentifier(k)
+		if err != nil {
+			return ra, errwrap.Wrap(fmt.Errorf("error parsing annotation key %q", k), err)
+		}
+
+		ra.Annotations.Set(*kAci, v)
+	}
+
 	if appRunConfig.UserAnnotations != nil {
 		ra.App.UserAnnotations = appRunConfig.UserAnnotations
 	}


### PR DESCRIPTION
Before this change, "app add" CLI allowed only to define
user annotations. User annotations were designed mostly
to store annotations from Kubernetes API. At the same time,
we want to store some data related to rktlet which aren't
k8s annotations (i.e. log directories for CRI-compatible
logs).

Defining annotations is allowed here by --annotation
CLI option (i.e. --annotation=foo=bar).

Ref #3813

---

TODO:
- [x] implementation
- [x] tests