### PR TITLE
rkt: skip parsing in case of an empty string

### DIFF
--- a/rkt/cli_apps.go
+++ b/rkt/cli_apps.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The rkt Authors
+// Copyright 2015-2017 The rkt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,9 @@ func parseApps(al *apps.Apps, args []string, flags *pflag.FlagSet, allowAppArgs 
 	inAppArgs := false
 	for i := 0; i < len(args); i++ {
 		a := args[i]
+		if len(a) == 0 {
+			continue
+		}
 		if inAppArgs {
 			switch a {
 			case "---":

--- a/rkt/cli_apps_test.go
+++ b/rkt/cli_apps_test.go
@@ -62,6 +62,15 @@ func TestParseAppArgs(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"example.com/foo  example.com/bar",
+			[]string{"example.com/foo", "example.com/bar"},
+			[][]string{
+				nil,
+				nil,
+			},
+			false,
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
When any string in `[]args` is empty, `""`, then the `al.Count()` gets still incremented, even if there's nothing to parse. As a result, `rkt app add` fails with an error message like `must give only one app`, even when only one app name is given.

For example, rktlet runs the following command:

```
rkt app --insecure-options=image,ondisk add 58992c0a-540d-40a4-bf39-4bb193d74f94 \
docker://busybox:1.26 --name=2-seccomp-container-docker-default-d25eafce-ad02-11e7-a670-2eecc98c9398d25eaff2-ad02-11e7-a670-2eecc98c9398 \
--user-annotation=k8s.io/reserved/image-name=busybox:1.26  --exec=top
```

Then the last part, `"  --exec=top"` is parsed to a list of 2 separate strings: `" "` and `"--exec=top"`, That's why `al.Count()` becomes 2.

See also https://github.com/kubernetes-incubator/rktlet/pull/146#issuecomment-334750394