### PR TITLE
makelib: Fix go-find-directories symlink problem

### DIFF
--- a/makelib/misc.mk
+++ b/makelib/misc.mk
@@ -172,7 +172,7 @@ endef
 # Example: $(call go-find-directories,./...,TestGoFiles XTestGoFiles,tests)
 define go-find-directories
 $(strip \
-	$(eval _MISC_GFD_ESCAPED_SRCDIR := $(MK_TOPLEVEL_ABS_SRCDIR)) \
+	$(eval _MISC_GFD_ESCAPED_SRCDIR := $(shell cd $(MK_TOPLEVEL_SRCDIR) && pwd)) \
 	$(eval _MISC_GFD_ESCAPED_SRCDIR := $(subst .,\.,$(_MISC_GFD_ESCAPED_SRCDIR))) \
 	$(eval _MISC_GFD_ESCAPED_SRCDIR := $(subst /,\/,$(_MISC_GFD_ESCAPED_SRCDIR))) \
 	$(eval _MISC_GFD_SPACE_ :=) \


### PR DESCRIPTION
Use the current working directory and not MK_TOPLEVEL_ABS_SRCDIR when
processing 'go list' output in go-find-directories.

Our invocation of 'go list' in the go-find-directories function uses
paths relative to the current working directory and so the output of
that command will have file paths based on the current working
directory.  The make file variable MK_TOPLEVEL_ABS_SRCDIR is initialized
with make's abspath function.  The abspath function (GNU Make 4.1) will
resolve symlinks.  This difference in resolved and unresolved symlinks
causes problems in the go-find-directories function output when building
from a path that includes a symlink.

Fixes 'make unit-check' errors like these when building in a directory
that has a symlink in its path:

  stat ./_/home/runner/workspace/src/github.com/.../builds/build-rkt-none/api/v1: no such file or directory

Semaphore-ci uses symlinks, and that is where I found this problem.

Here's a simple test:

    git clone https://github.com/coreos/rkt rkt-src
    mkdir test
    ln -s ../rkt-src test/
    cd test/rkt-src
    ./tests/build-and-run-tests.sh -f none -c
