### PR TITLE
tests: Use semaphore install-package

### DIFF
--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -20,22 +20,17 @@ if [ "${CI-}" == true ] ; then
 		# Semaphore installs more dependencies on their
 		# platform, they should be removed from here to save time.
 
-		# If there is some dependency to install then
-		# uncomment the following line and add "sudo apt-get
-		# install -y <dep>" after it.
-
-		sudo apt-get update -qq || true
-		sudo apt-get install -y libacl1-dev bc libsystemd-journal-dev
+		install-package libacl1-dev bc libsystemd-journal-dev
 
 		# libmount: https://github.com/systemd/systemd/pull/986#issuecomment-138451264
 		sudo add-apt-repository --yes ppa:pitti/systemd-semaphore
 		sudo apt-get update -qq || true
-		sudo apt-get install -y libmount-dev libmount1
+		install-package libmount-dev libmount1
 
 		# building systemd v229 crashes with the gcc 4.8, update to gcc 5
 		sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-		sudo apt-get update -qq
-		sudo apt-get install gcc-5 gcc-5-base libgcc-5-dev g++-5 libstdc++-5-dev libseccomp-dev -y -qq
+		sudo apt-get update -qq || true
+		install-package gcc-5 gcc-5-base libgcc-5-dev g++-5 libstdc++-5-dev libseccomp-dev
 		sudo update-alternatives --remove-all gcc
 		sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20
 		sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20


### PR DESCRIPTION
When running on semaphore use thier install-package to
take advantage of package caching.