### PR TITLE
stage0/run: relax '--hosts-entry' parser

### DIFF
--- a/rkt/run.go
+++ b/rkt/run.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -643,13 +644,8 @@ func parseDNSFlags(flagHostsEntries, flagDNS, flagDNSSearch, flagDNSOpt []string
 	// Parse out --hosts-entries, also looking for the magic value "host"
 	for _, entry := range flagHostsEntries {
 		if entry == "host" {
-			if len(flagHostsEntries) == 1 {
-				DNSConfMode.Hosts = "host"
-			} else {
-				return DNSConfMode, DNSConfig, &HostsEntries,
-					fmt.Errorf("cannot pass --hosts-entry=host with multiple hosts-entries")
-			}
-			break
+			DNSConfMode.Hosts = "host"
+			continue
 		}
 		for _, entry := range strings.Split(entry, ",") {
 			vals := strings.SplitN(entry, "=", 2)
@@ -677,6 +673,10 @@ func parseDNSFlags(flagHostsEntries, flagDNS, flagDNSSearch, flagDNSOpt []string
 	}
 
 	if len(HostsEntries) > 0 {
+		if DNSConfMode.Hosts == "host" {
+			return DNSConfMode, DNSConfig, &HostsEntries,
+				errors.New("cannot pass --hosts-entry=host with multiple hosts-entries")
+		}
 		DNSConfMode.Hosts = "stage0"
 	}
 

--- a/tests/rkt_etc_hosts_test.go
+++ b/tests/rkt_etc_hosts_test.go
@@ -80,6 +80,11 @@ func TestEtcHosts(t *testing.T) {
 			"--exec=/inspect -- -file-name=/etc/hosts -hash-file",
 			sum,
 		},
+		{ // Test that multiple '--hosts-entry=host' entries are fine
+			"--hosts-entry=host --hosts-entry=host",
+			"--exec=/inspect -- -file-name=/etc/hosts -hash-file",
+			sum,
+		},
 		{ // test that we create our own
 			"--hosts-entry=128.66.0.99=host1",
 			"--exec=/inspect -- -file-name=/etc/hosts -read-file",


### PR DESCRIPTION
This tweaks the '--hosts-entry' CLI flag parser to accept multiple
time the special value "host" when there are no other conflicting
settings.