### PR TITLE
scripts: Add libfdt to install deps

### DIFF
--- a/scripts/install-deps-debian-sid.sh
+++ b/scripts/install-deps-debian-sid.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DEBIAN_SID_DEPS="ca-certificates gcc libc6-dev gpg gpg-agent make automake wget git golang-go coreutils cpio squashfs-tools autoconf file xz-utils patch bc locales libacl1-dev libssl-dev libtspi-dev libsystemd-dev python pkg-config zlib1g-dev libglib2.0-dev libpixman-1-dev libcap-dev"
+DEBIAN_SID_DEPS="ca-certificates gcc libc6-dev gpg gpg-agent make automake wget git golang-go coreutils cpio squashfs-tools autoconf file xz-utils patch bc locales libacl1-dev libssl-dev libtspi-dev libsystemd-dev python pkg-config zlib1g-dev libglib2.0-dev libpixman-1-dev libcap-dev libfdt-dev"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update

--- a/scripts/install-deps-fedora-22.sh
+++ b/scripts/install-deps-fedora-22.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-FEDORA22_DEPS="make gcc glibc-devel glibc-static cpio squashfs-tools gpg autoconf automake golang file git wget tar xz patch bc hostname findutils openssl libacl-devel openssl-devel systemd-devel"
+FEDORA22_DEPS="make gcc glibc-devel glibc-static cpio squashfs-tools gpg autoconf automake golang file git wget tar xz patch bc hostname findutils openssl libacl-devel openssl-devel systemd-devel libfdt-devel"
 
 dnf install -y ${FEDORA22_DEPS}


### PR DESCRIPTION
libfdt-dev is needed when building kernels for architectures that
support a device tree.

Fixes build errors like these when building kvm+lkvm flavor for
ARM64:

  make[1]: Entering directory 'build/tmp/usr_from_kvm/lkvm/src'
  Makefile: No libfdt found. Please install libfdt-dev package. Stop.

Related to: https://github.com/rkt/rkt/pull/3829