### PR TITLE
stage1: execute pre-start/post-stop hooks as privileged

### DIFF
--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -551,6 +551,7 @@ func (uw *UnitWriter) appSystemdUnit(pa *preparedApp, binPath string, opts []*un
 		unit.NewUnitOption("Service", "EnvironmentFile", RelEnvFilePath(appName)),
 		unit.NewUnitOption("Service", "User", strconv.Itoa(int(pa.uid))),
 		unit.NewUnitOption("Service", "Group", strconv.Itoa(int(pa.gid))),
+		unit.NewUnitOption("Service", "PermissionsStartOnly", "true"),
 		unit.NewUnitOption("Unit", "Requires", InstantiatedPrepareAppUnitName(ra.Name)),
 		unit.NewUnitOption("Unit", "After", InstantiatedPrepareAppUnitName(ra.Name)),
 	)

--- a/tests/rkt_run_test.go
+++ b/tests/rkt_run_test.go
@@ -18,9 +18,16 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 
+	"github.com/rkt/rkt/common"
+	"github.com/rkt/rkt/pkg/aci/acitest"
 	"github.com/rkt/rkt/tests/testutils"
+
+	"github.com/appc/spec/schema"
+	"github.com/appc/spec/schema/types"
 )
 
 // TestRunConflictingFlags tests that 'rkt run' will complain and abort
@@ -60,4 +67,48 @@ func TestRunConflictingFlags(t *testing.T) {
 		cmd := fmt.Sprintf("%s run dummy-image.aci %s %s%s", ctx.Cmd(), podManifestFlag, icf.flag, icf.args)
 		runRktAndCheckOutput(t, cmd, runConflictingFlagsMsg, true)
 	}
+}
+
+// TestPreStart tests that pre-start events are run, and they run as root even
+// when the app itself runs as an unprivileged user.
+func TestPreStart(t *testing.T) {
+	prestartManifest := schema.ImageManifest{
+		Name: "coreos.com/rkt-prestart-test",
+		App: &types.App{
+			Exec: types.Exec{"/inspect"},
+			User: "1000", Group: "1000",
+			WorkingDirectory: "/",
+			EventHandlers: []types.EventHandler{
+				{"pre-start", types.Exec{
+					"/inspect",
+					"--print-user",
+				}},
+			},
+		},
+		Labels: types.Labels{
+			{"version", "1.29.0"},
+			{"arch", common.GetArch()},
+			{"os", common.GetOS()},
+		},
+	}
+
+	prestartManifestStr, err := acitest.ImageManifestString(&prestartManifest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prestartManifestFile := "prestart-manifest.json"
+	if err := ioutil.WriteFile(prestartManifestFile, []byte(prestartManifestStr), 0600); err != nil {
+		t.Fatalf("Cannot write prestart manifest: %v", err)
+	}
+	defer os.Remove(prestartManifestFile)
+	prestartImage := patchTestACI("rkt-prestart.aci", fmt.Sprintf("--manifest=%s", prestartManifestFile))
+	defer os.Remove(prestartImage)
+
+	ctx := testutils.NewRktRunCtx()
+	defer ctx.Cleanup()
+
+	rktCmd := fmt.Sprintf("%s --insecure-options=image run %s", ctx.Cmd(), prestartImage)
+	expectedLine := "User: uid=0 euid=0 gid=0 egid=0"
+	runRktAndCheckOutput(t, rktCmd, expectedLine, false)
 }


### PR DESCRIPTION
Even if we run the container as an unprivileged user.

Usually, pre-start and post-stop are used to initialize or shut down a
service, and very often this needs privileges.