### PR TITLE
list: add ip of non-running pods to status output

### DIFF
--- a/pkg/pod/pods.go
+++ b/pkg/pod/pods.go
@@ -269,7 +269,7 @@ func getPod(dataDir string, uuid *types.UUID) (*Pod, error) {
 
 	p.FileLock = l
 
-	if p.isRunning() {
+	if p.isRunning() || p.isExit() {
 		cfd, err := p.Fd()
 		if err != nil {
 			return nil, errwrap.Wrap(fmt.Errorf("error acquiring pod %v dir fd", uuid), err)
@@ -1198,6 +1198,11 @@ func (p *Pod) IsAfterRun() bool {
 // IsFinished returns true if the pod is in a terminal state, else false.
 func (p *Pod) IsFinished() bool {
 	return p.isExited || p.isAbortedPrepare || p.isGarbage || p.isGone
+}
+
+// isExit returns true if the pod is in exited states
+func (p *Pod) isExit() bool {
+	return p.isExited
 }
 
 // AppExitCode returns the app's exit code.

--- a/rkt/api_service.go
+++ b/rkt/api_service.go
@@ -537,6 +537,7 @@ func fillPodDetails(store *imagestore.Store, p *pkgPod.Pod, v1pod *v1alpha.Pod) 
 		v1pod.State = v1alpha.PodState_POD_STATE_DELETING
 	case pkgPod.Exited:
 		v1pod.State = v1alpha.PodState_POD_STATE_EXITED
+		v1pod.Networks = getNetworks(p)
 	case pkgPod.Garbage, pkgPod.ExitedGarbage:
 		v1pod.State = v1alpha.PodState_POD_STATE_GARBAGE
 	default:

--- a/rkt/status.go
+++ b/rkt/status.go
@@ -212,7 +212,7 @@ func printStatus(p *pkgPod.Pod) error {
 		stdout.Printf("started=%s", startedStr)
 	}
 
-	if state == pkgPod.Running {
+	if state == pkgPod.Running || state == pkgPod.Exited {
 		stdout.Printf("networks=%s", fmtNets(p.Nets))
 	}
 

--- a/tests/rkt_list_test.go
+++ b/tests/rkt_list_test.go
@@ -57,6 +57,14 @@ func TestRktList(t *testing.T) {
 	// Get hash
 	imageID := fmt.Sprintf("sha512-%s", imgID.hash[:12])
 
+	cmd = fmt.Sprintf("%s --insecure-options=image run-prepared %s", ctx.Cmd(), podUuid)
+	nobodyUid, _ := testutils.GetUnprivilegedUidGid()
+	_, status := runRkt(t, cmd, nobodyUid, 0)
+	if status != 0 {
+		panic(fmt.Errorf("expected exit status code 0, got %d", status))
+	}
+	podInfo := getPodInfo(t, ctx, podUuid)
+	ipv4 := podInfo.networks["default"].ipv4
 	// Define tests
 	tests := []struct {
 		cmd           string
@@ -98,6 +106,12 @@ func TestRktList(t *testing.T) {
 			"list --full",
 			true,
 			imageID,
+		},
+		//	Test that ip is in json output
+		{
+			"list --format=json",
+			true,
+			ipv4,
 		},
 	}
 


### PR DESCRIPTION
partial fix for #3550 
ip of the non running pod is added to the json output