### PR TITLE
rkt: prevent skipping some images in image gc

### DIFF
--- a/rkt/image_gc.go
+++ b/rkt/image_gc.go
@@ -150,7 +150,7 @@ func gcStore(s *imagestore.Store, gracePeriod time.Duration) error {
 			break
 		}
 		if isInSet(ai.BlobKey, runningImages) {
-			break
+			continue
 		}
 		imagesToRemove = append(imagesToRemove, ai.BlobKey)
 	}


### PR DESCRIPTION
We were using break when we found an image with a pod in running state
but that means we'll miss subsequent images for non-running pods.

Change the break to a continue to keep processing the rest.