### PR TITLE
doc: OCI & appc/spec clarification

### DIFF
--- a/Documentation/app-container.md
+++ b/Documentation/app-container.md
@@ -4,7 +4,7 @@
 
 rkt's native [image format](#aci) and [runtime environment](#pods) are those defined by the [specification][appc-spec].
 
-_Note that as of late 2016, appc is [no longer being actively developed](https://github.com/appc/spec#-disclaimer-), and future versions of rkt will instead [natively use OCI formats](https://github.com/rkt/rkt/projects/4)._
+_Note that as of late 2016, appc is [no longer being actively developed, other than minor tweaks](https://github.com/appc/spec#-disclaimer-). However, appc is fully functional and stable and will continue to be supported. Future versions of rkt might gain [native support of OCI formats](https://github.com/rkt/rkt/projects/4)._
 
 ## ACI
 

--- a/Documentation/proposals/oci.md
+++ b/Documentation/proposals/oci.md
@@ -35,6 +35,8 @@ Currently rkt does support ACI, Docker, and OCI images, but the conversion step 
 It introduces CPU and I/O bound overhead and is bound by semantical differences between the formats. For these reasons native support of OCI images inside rkt is envisioned.
 
 The goal therefore is to support OCI images natively next to ACI.
+rkt will continue to support the ACI image format and distribution mechanism.
+There is currently no plans to remove that support.
 
 This document outlines the following necessary steps and references existing work to transition to native OCI image support in rkt:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,16 @@ rkt's version 1.0 release marks the command line user interface and on-disk data
 
 ## Ongoing projects
 
-- [Kubernetes CRI](https://github.com/rkt/rkt/projects/1): adapting rkt to offer first-class implementation of the Kubernetes Container Runtime Interface.
-- [OCI native support](https://github.com/rkt/rkt/projects/4): supporting OCI specs natively in rkt.
-- [appc phase-out](https://github.com/rkt/rkt/projects/5): following OCI evolution and stabilization, appc will be naturally deprecated and phased-out.
+### [Kubernetes CRI](https://github.com/rkt/rkt/projects/1)
+
+Adapting rkt to offer first-class implementation of the Kubernetes Container Runtime Interface.
+
+### [OCI native support](https://github.com/rkt/rkt/projects/4)
+
+Supporting OCI specs natively in rkt.
+Following OCI evolution and stabilization, it will become the preferred way over appc.
+However, rkt will continue to support the ACI image format and distribution mechanism.
+There is currently no plans to remove that support from rkt.
 
 ### Upcoming
 


### PR DESCRIPTION
The documentation about OCI and appc created uncertainty for users, as
shown by the issues #3777 and #3745.

This is an attempt to clarify that although not much development is
happening in appc, rkt will not drop the ACI support.

Once this PR is merged, I would like to delete the project
https://github.com/rkt/rkt/projects/5 as it does not contain anything
and we have https://github.com/rkt/rkt/projects/4 to track the progress
of OCI native support.

Fixes https://github.com/rkt/rkt/issues/3777
Fixes https://github.com/rkt/rkt/issues/3745