### PR TITLE
iottymux: add support for json formatted logs akin to docker

### DIFF
--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -337,9 +337,9 @@ func (uw *UnitWriter) SetupAppIO(p *stage1commontypes.Pod, ra *schema.RuntimeApp
 				}
 				file.WriteString(fmt.Sprintf("KUBERNETES_LOG_PATH=%s\n", kubernetesLogPath))
 
-            case "json-file":
-                jsonLogFile, ok := ra.Annotations.Get("coreos.com/rkt/experiment/json-log-file")
-                
+			case "json-file":
+				jsonLogFile, ok := ra.Annotations.Get("coreos.com/rkt/experiment/json-log-file")
+
 				if !ok {
 					uw.err = fmt.Errorf("json-log-file annotation needs to be specified when json-file logging mode is used")
 					return nil

--- a/stage1/init/common/units.go
+++ b/stage1/init/common/units.go
@@ -336,6 +336,15 @@ func (uw *UnitWriter) SetupAppIO(p *stage1commontypes.Pod, ra *schema.RuntimeApp
 					return nil
 				}
 				file.WriteString(fmt.Sprintf("KUBERNETES_LOG_PATH=%s\n", kubernetesLogPath))
+
+            case "json-file":
+                jsonLogFile, ok := ra.Annotations.Get("coreos.com/rkt/experiment/json-log-file")
+                
+				if !ok {
+					uw.err = fmt.Errorf("json-log-file annotation needs to be specified when json-file logging mode is used")
+					return nil
+				}
+				file.WriteString(fmt.Sprintf("JSON_LOG_FILE=%s\n", jsonLogFile))
 			}
 
 		} else if needsTTYMux {

--- a/stage1/init/init.go
+++ b/stage1/init/init.go
@@ -367,6 +367,11 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, canMachinedRegister boo
 			args = append(args, fmt.Sprintf("--bind=%s:/rkt/kubernetes/log", kubernetesLogDir))
 		}
 
+		jsonLogDir, ok := p.Manifest.Annotations.Get("coreos.com/rkt/experiment/json-log-dir")
+		if ok {
+			args = append(args, fmt.Sprintf("--bind=%s:/rkt/json/log", jsonLogDir))
+		}
+
 		// use only dynamic libraries provided in the image
 		// from systemd v231 there's a new internal libsystemd-shared-v231.so
 		// which is present in /usr/lib/systemd
@@ -397,6 +402,10 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, canMachinedRegister boo
 		kubernetesLogDir, ok := p.Manifest.Annotations.Get("coreos.com/rkt/experiment/kubernetes-log-dir")
 		if ok {
 			args = append(args, fmt.Sprintf("--bind=%s:/rkt/kubernetes/log", kubernetesLogDir))
+		}
+		jsonLogDir, ok := p.Manifest.Annotations.Get("coreos.com/rkt/experiment/json-log-dir")
+		if ok {
+			args = append(args, fmt.Sprintf("--bind=%s:/var/lib/rkt/log", jsonLogDir))
 		}
 
 		// use only dynamic libraries provided in the image
@@ -452,6 +461,11 @@ func getArgsEnv(p *stage1commontypes.Pod, flavor string, canMachinedRegister boo
 		kubernetesLogDir, ok := p.Manifest.Annotations.Get("coreos.com/rkt/experiment/kubernetes-log-dir")
 		if ok {
 			args = append(args, fmt.Sprintf("--bind=%s:/rkt/kubernetes/log", kubernetesLogDir))
+		}
+
+		jsonLogDir, ok := p.Manifest.Annotations.Get("coreos.com/rkt/experiment/json-log-dir")
+		if ok {
+			args = append(args, fmt.Sprintf("--bind=%s:/var/lib/rkt/log", jsonLogDir))
 		}
 
 	default:

--- a/stage1/iottymux/iottymux.go
+++ b/stage1/iottymux/iottymux.go
@@ -77,6 +77,12 @@ type Targets struct {
 	Targets []Endpoint `json:"targets"`
 }
 
+type JSONLog struct {
+    Time    string      `json:"time"`
+    Message string      `json:"log,omitempty"`
+    Stream  string      `json:"stream,omitempty"`
+}
+
 // iottymux is a multi-action binary which can be used for:
 //  * creating and muxing a TTY for an application
 //  * proxying streams for an application (stdin/stdout/stderr) over TCP
@@ -407,6 +413,7 @@ func actionIOMux(statusFile string) error {
 	// TODO(lucab): finalize custom logging modes
 	logMode := os.Getenv("STAGE1_LOGMODE")
 	var logFile *os.File
+    var format func(time string, line []byte, stream string) []byte 
 	switch logMode {
 	case "k8s-plain":
 		var err error
@@ -428,6 +435,41 @@ func actionIOMux(statusFile string) error {
 			return err
 		}
 		defer logFile.Close()
+
+        format = func(timestamp string, line []byte, stream string) []byte {
+            return []byte(fmt.Sprintf("%s %s %s", timestamp, stream, line))
+        }
+    
+    case "json-file":
+        var err error
+
+        logFileName := os.Getenv("JSON_LOG_FILE")
+        logFullPath := filepath.Clean(filepath.Join("/rkt/json/log", logFileName))
+
+        match, err := filepath.Match("/rkt/json/log/*", logFullPath)
+		if err != nil {
+			return fmt.Errorf("couldn't analyze the full log path %s: %s", logFullPath, err)
+		} else if !match {
+			return fmt.Errorf("log path is not inside /rkt/json/log, refusing path traversal")
+		}
+
+		logFile, err = os.OpenFile(logFullPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+		if err != nil {
+			return err
+		}
+		defer logFile.Close()
+
+        format = func(timestamp string, line []byte, stream string) []byte {
+            diag.Println(string(line))
+            result, err := json.Marshal(JSONLog{Time: timestamp, Stream: stream, Message: string(line)})
+            if err != nil {
+                log.Println("Could not convert log to JSON: %s", line)
+            }
+            result = append(result, '\n')
+            diag.Println(string(result))
+            return result
+        }
+
 	}
 
 	// proxy stdin
@@ -444,7 +486,7 @@ func actionIOMux(statusFile string) error {
 		lines := make(chan []byte)
 		go bufferLine(streams[1].fifo, lines, c)
 		go acceptConn(streams[1].listener, clients, "stdout")
-		go muxOutput("stdout", lines, clients, localTargets)
+		go muxOutput("stdout", lines, clients, localTargets, format)
 		if logFile != nil {
 			localTargets <- logFile
 		}
@@ -457,7 +499,7 @@ func actionIOMux(statusFile string) error {
 		lines := make(chan []byte)
 		go bufferLine(streams[2].fifo, lines, c)
 		go acceptConn(streams[2].listener, clients, "stderr")
-		go muxOutput("stderr", lines, clients, localTargets)
+		go muxOutput("stderr", lines, clients, localTargets, format)
 		if logFile != nil {
 			localTargets <- logFile
 		}
@@ -582,22 +624,23 @@ func bufferInput(conn net.Conn, stdin *os.File) {
 
 // muxOutput receives remote clients and local log targets,
 // multiplexing output lines to them
-func muxOutput(streamLabel string, lines chan []byte, clients <-chan net.Conn, targets <-chan io.WriteCloser) {
+func muxOutput(streamLabel string, lines chan []byte, clients <-chan net.Conn, targets <-chan io.WriteCloser, format func(timestamp string, line []byte, stream string) []byte) {
 	var logs []io.WriteCloser
 	var conns []io.WriteCloser
+    
+    writeAndFilter := func(wc io.WriteCloser, line []byte) bool {
+        _, err := wc.Write(line)
+        if err != nil {
+            wc.Close()
+        }
+        return err != nil
+    }
 
-	writeAndFilter := func(wc io.WriteCloser, line []byte) bool {
-		_, err := wc.Write(line)
-		if err != nil {
-			wc.Close()
-		}
-		return err != nil
-	}
 
-	logsWriteAndFilter := func(wc io.WriteCloser, line []byte) bool {
-		out := []byte(fmt.Sprintf("%s %s %s", time.Now().Format(time.RFC3339Nano), streamLabel, line))
-		return writeAndFilter(wc, out)
-	}
+    logsWriteAndFilter := func(wc io.WriteCloser, line []byte) bool {
+        out := format(time.Now().Format(time.RFC3339Nano), line, streamLabel)
+        return writeAndFilter(wc, out)
+    }
 
 	for {
 		select {

--- a/stage1/iottymux/iottymux.go
+++ b/stage1/iottymux/iottymux.go
@@ -627,20 +627,20 @@ func bufferInput(conn net.Conn, stdin *os.File) {
 func muxOutput(streamLabel string, lines chan []byte, clients <-chan net.Conn, targets <-chan io.WriteCloser, format func(timestamp string, line []byte, stream string) []byte) {
 	var logs []io.WriteCloser
 	var conns []io.WriteCloser
-    
-    writeAndFilter := func(wc io.WriteCloser, line []byte) bool {
-        _, err := wc.Write(line)
-        if err != nil {
-            wc.Close()
-        }
-        return err != nil
-    }
+	
+	writeAndFilter := func(wc io.WriteCloser, line []byte) bool {
+		_, err := wc.Write(line)
+		if err != nil {
+			wc.Close()
+		}
+		return err != nil
+	}
 
 
-    logsWriteAndFilter := func(wc io.WriteCloser, line []byte) bool {
-        out := format(time.Now().Format(time.RFC3339Nano), line, streamLabel)
-        return writeAndFilter(wc, out)
-    }
+	logsWriteAndFilter := func(wc io.WriteCloser, line []byte) bool {
+		out := format(time.Now().Format(time.RFC3339Nano), line, streamLabel)
+		return writeAndFilter(wc, out)
+	}
 
 	for {
 		select {

--- a/stage1/iottymux/iottymux.go
+++ b/stage1/iottymux/iottymux.go
@@ -78,9 +78,9 @@ type Targets struct {
 }
 
 type JSONLog struct {
-    Time    string      `json:"time"`
-    Message string      `json:"log,omitempty"`
-    Stream  string      `json:"stream,omitempty"`
+	Time    string `json:"time"`
+	Message string `json:"log,omitempty"`
+	Stream  string `json:"stream,omitempty"`
 }
 
 // iottymux is a multi-action binary which can be used for:
@@ -413,7 +413,7 @@ func actionIOMux(statusFile string) error {
 	// TODO(lucab): finalize custom logging modes
 	logMode := os.Getenv("STAGE1_LOGMODE")
 	var logFile *os.File
-    var format func(time string, line []byte, stream string) []byte 
+	var format func(time string, line []byte, stream string) []byte
 	switch logMode {
 	case "k8s-plain":
 		var err error
@@ -436,17 +436,17 @@ func actionIOMux(statusFile string) error {
 		}
 		defer logFile.Close()
 
-        format = func(timestamp string, line []byte, stream string) []byte {
-            return []byte(fmt.Sprintf("%s %s %s", timestamp, stream, line))
-        }
-    
-    case "json-file":
-        var err error
+		format = func(timestamp string, line []byte, stream string) []byte {
+			return []byte(fmt.Sprintf("%s %s %s", timestamp, stream, line))
+		}
 
-        logFileName := os.Getenv("JSON_LOG_FILE")
-        logFullPath := filepath.Clean(filepath.Join("/rkt/json/log", logFileName))
+	case "json-file":
+		var err error
 
-        match, err := filepath.Match("/rkt/json/log/*", logFullPath)
+		logFileName := os.Getenv("JSON_LOG_FILE")
+		logFullPath := filepath.Clean(filepath.Join("/rkt/json/log", logFileName))
+
+		match, err := filepath.Match("/rkt/json/log/*", logFullPath)
 		if err != nil {
 			return fmt.Errorf("couldn't analyze the full log path %s: %s", logFullPath, err)
 		} else if !match {
@@ -459,16 +459,16 @@ func actionIOMux(statusFile string) error {
 		}
 		defer logFile.Close()
 
-        format = func(timestamp string, line []byte, stream string) []byte {
-            diag.Println(string(line))
-            result, err := json.Marshal(JSONLog{Time: timestamp, Stream: stream, Message: string(line)})
-            if err != nil {
-                log.Println("Could not convert log to JSON: %s", line)
-            }
-            result = append(result, '\n')
-            diag.Println(string(result))
-            return result
-        }
+		format = func(timestamp string, line []byte, stream string) []byte {
+			diag.Println(string(line))
+			result, err := json.Marshal(JSONLog{Time: timestamp, Stream: stream, Message: string(line)})
+			if err != nil {
+				log.Println("Could not convert log to JSON: %s", line)
+			}
+			result = append(result, '\n')
+			diag.Println(string(result))
+			return result
+		}
 
 	}
 
@@ -627,7 +627,7 @@ func bufferInput(conn net.Conn, stdin *os.File) {
 func muxOutput(streamLabel string, lines chan []byte, clients <-chan net.Conn, targets <-chan io.WriteCloser, format func(timestamp string, line []byte, stream string) []byte) {
 	var logs []io.WriteCloser
 	var conns []io.WriteCloser
-	
+
 	writeAndFilter := func(wc io.WriteCloser, line []byte) bool {
 		_, err := wc.Write(line)
 		if err != nil {
@@ -635,7 +635,6 @@ func muxOutput(streamLabel string, lines chan []byte, clients <-chan net.Conn, t
 		}
 		return err != nil
 	}
-
 
 	logsWriteAndFilter := func(wc io.WriteCloser, line []byte) bool {
 		out := format(time.Now().Format(time.RFC3339Nano), line, streamLabel)

--- a/tests/rkt_app_sandbox_test.go
+++ b/tests/rkt_app_sandbox_test.go
@@ -668,25 +668,25 @@ func TestAppSandboxJSONFileLogs(t *testing.T) {
 			// same as CRI logs just above
 			var content []byte
 			var err error
-            var sContent string
+			var sContent string
 			for i := 0; i < logsReadRetries; i++ {
-                err = nil
+				err = nil
 				jsonLogFullPath := path.Join(tt.jsonLogDir, tt.jsonLogFile)
 				content, err = ioutil.ReadFile(jsonLogFullPath)
-                if err == nil {
-                    sContent = string(content)
-                    if len(sContent) > 0 {
-                        break
-                    }
-                }
+				if err == nil {
+					sContent = string(content)
+					if len(sContent) > 0 {
+						break
+					}
+				}
 				time.Sleep(logsReadRetryDelay)
 			}
-            if err != nil {
-                t.Fatal(err)
-            }
-            if !(strings.Contains(sContent, "\"log\":\"HelloFromAppInSandbox\\n\"") && strings.Contains(sContent, "\"stream\":\"stdout\"")) {
-                t.Fatalf("Expected json logs to contain '\"log\":\"HelloFromAppInSandbox\\n\"' and '\"stream\":\"stdout\"', instead got: %s", sContent)
-            }
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !(strings.Contains(sContent, "\"log\":\"HelloFromAppInSandbox\\n\"") && strings.Contains(sContent, "\"stream\":\"stdout\"")) {
+				t.Fatalf("Expected json logs to contain '\"log\":\"HelloFromAppInSandbox\\n\"' and '\"stream\":\"stdout\"', instead got: %s", sContent)
+			}
 
 		})
 	}


### PR DESCRIPTION
This PR piggybacks on the `k8s-plain` format introduced in #3798 which allowed for CRI compliant output out of the iottymux module. It introduces a json format option, mimicking docker log's default style.

Me and my partner @jyouchan were playing around with the rkt repository for a final project in our upper division virtualization class. We ended up implementing docker style json logging as a proof of concept, and thought that it might be useful. Feel free to reject the PR if it doesn't align with rkt's goals!