### PR TITLE
Documentation: update compression note for journal files

### DIFF
--- a/Documentation/using-rkt-with-systemd.md
+++ b/Documentation/using-rkt-with-systemd.md
@@ -67,15 +67,15 @@ MACHINE CLASS SERVICE
 0 machines listed.
 ```
 
-Note that journald integration is only supported if systemd is compiled with `xz` compression enabled. To inspect this, use `systemctl`:
+Note that, for the "coreos" and "kvm" stage1 flavors, journald integration is only supported if systemd is compiled with `lz4` compression enabled. To inspect this, use `systemctl`:
 
 ```
 $ systemctl --version
-systemd v231
-[...] +XZ [...]
+systemd 235
+[...] +LZ4 [...]
 ```
 
-If the output contains `-XZ`, journal entries will not be available.
+If the output contains `-LZ4`, journal entries will not be available.
 
 ## Managing pods as systemd services
 


### PR DESCRIPTION
Container Linux enabled lz4 support for journald[[1]], which means logs
started being written compressed with the lz4 format instead of xz.

Change the note about host's systemd compression support needed from xz
to lz4.

Also, clarify that this only applies to the coreos and kvm flavors.
Users of the host flavor will not be impacted since the systemd used in
stage1 will be the same as on the host.

[1]: https://github.com/coreos/coreos-overlay/pull/2593

Fixes #3839 