### PR TITLE
build/stage1: fix makefile for busybox environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,4 @@ Linux 3.18+ is required to successfully garbage collect rkt pods when system ser
 
 - [Projects integrating with rkt](https://github.com/rkt/rkt/blob/master/Documentation/integrations.md)
 - [Production users](https://github.com/rkt/rkt/blob/master/Documentation/production-users.md)
+

--- a/stage1/usr_from_coreos/build-usr.mk
+++ b/stage1/usr_from_coreos/build-usr.mk
@@ -161,7 +161,7 @@ $(call generate-clean-mk-from-filelist, \
 # This unpacks squashfs image to a temporary rootfs.
 $(call generate-stamp-rule,$(CBU_MKBASE_STAMP),$(CCN_SQUASHFS) $(CBU_COMPLETE_MANIFEST),$(CBU_ROOTFS), \
 	$(call vb,vt,UNSQUASHFS,$(call vsp,$(CCN_SQUASHFS)) => $(call vsp,$(CBU_ROOTFS)/usr)) \
-	CBU_SQROOT=$$$$(unsquashfs -ls "$(CCN_SQUASHFS)" --no-progress | tail --lines=1); \
+	CBU_SQROOT=$$$$(unsquashfs -ls "$(CCN_SQUASHFS)" --no-progress | tail -1); \
 	unsquashfs -ls "$(CCN_SQUASHFS)" | grep "^$$$${CBU_SQROOT}" | sed -e "s/$$$${CBU_SQROOT}\///g" | sort >"$(CBU_SQUASHFS_FILES)"; \
 	comm -1 -2 "$(CBU_SQUASHFS_FILES)" "$(CBU_COMPLETE_MANIFEST)" >"$(CBU_COMMON_FILES)"; \
 	if ! cmp --silent "$(CBU_COMMON_FILES)" "$(CBU_COMPLETE_MANIFEST)"; \

--- a/stage1/usr_from_kvm/qemu.mk
+++ b/stage1/usr_from_kvm/qemu.mk
@@ -8,13 +8,18 @@ QEMU_BIOS_BINARIES := bios-256k.bin \
     linuxboot_dma.bin \
     vgabios-stdvga.bin \
     efi-virtio.rom
+ifeq ($(QEMU_PYTHON_BINARY),)
+QEMU_PYTHON_BINARY = $(shell which python)
+echo $(shell echo QEMU_PYTHON_BINARY unset, setting to `which python`: $(QEMU_PYTHON_BINARY))
+endif
+
 
 QEMU_CONFIGURATION_OPTS := --disable-bsd-user --disable-docs --disable-guest-agent --disable-guest-agent-msi \
     --disable-sdl --disable-gtk --disable-vte --disable-curses --disable-cocoa --disable-brlapi --disable-vnc \
     --disable-seccomp --disable-curl --disable-bluez --disable-cap-ng --disable-rbd --disable-libiscsi \
     --disable-libnfs --disable-smartcard --disable-libusb --disable-glusterfs --disable-archipelago \
     --disable-tcmalloc --disable-jemalloc --disable-debug-info --static --enable-virtfs --target-list=x86_64-softmmu \
-    --python=/usr/bin/python2 --disable-werror
+    --python=$(QEMU_PYTHON_BINARY) --disable-werror
 QEMU_ACI_BINARY := $(HV_ACIROOTFSDIR)/qemu
 
 # Using 2.7.0 stable release from official repository


### PR DESCRIPTION
recommending standard 'tail -n' argument here.
why?
not all tails (busybox) support nicer-looking 'tail --lines=n'.