### PR TITLE
scripts/build-pkgs: use RPM file dependency for shadow tools

### DIFF
--- a/scripts/pkg/build-pkgs.sh
+++ b/scripts/pkg/build-pkgs.sh
@@ -104,7 +104,7 @@ fpm -s dir -t rpm \
 	--after-upgrade $workdir/after-install \
     --license "$LICENSE" --vendor "$VENDOR" --url "$HOMEPAGE" -m "$MAINTAINER" --category utils \
     --provides rkt \
-    -d 'shadow-utils' \
+    -d '/usr/sbin/groupadd' \
     -C ${prefix} 
 
 rm -rf $workdir


### PR DESCRIPTION
Different RPM distributions use different packages to collect the
various tools from the 'shadow' package so we could use the path
from one of these tools in order to allow the rkt package to be used
in more RPM distributions.

Fixes: #3908 