### PR TITLE
kvm: solve certain routing issues by using the same default bridge as CNI

### DIFF
--- a/networking/kvm.go
+++ b/networking/kvm.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	defaultBrName     = "kvm-cni0"
+	defaultBrName     = "cni0"
 	defaultSubnetFile = "/run/flannel/subnet.env"
 	defaultMTU        = 1500
 )


### PR DESCRIPTION
When the kvm stage1 and the coreos stage1 are used on the same machine with a
flannel CNI configuration (and likely other configurations) without a specified
bridge name, different bridges will be constructed by each stage1 for the same
subnet -- cni0 and kvm-cni0 -- causing traffic intended for the
later-constructed bridge to be lost, as it is routed to the earlier-constructed
bridge.

The normal workaround is to specify a bridge name in the CNI configuration, but
this fix avoids the issue altogether by making sure that cni0 is used in all
cases.

I can't find any records of a specific motivation for using kvm-cni0 instead of cni0, so it's possible that I'm missing the original reason behind it, but it seems like an arbitrarily-made decision from the original development of CNI support in the kvm stage1.