### PR TITLE
Fix NixOS install instructions

### DIFF
--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -95,10 +95,16 @@ sudo emerge rkt
 
 ## NixOS
 
-rkt can be installed on NixOS using the following command:
+On NixOS enable rkt by adding the following line in `/etc/nixos/configuration.nix`:
 
 ```
-nix-env -iA rkt
+virtualisation.rkt.enable = true;
+```
+
+Using the nix package manager on another OS you can use:
+
+```
+nix-env -iA nixos.rkt
 ```
 
 The source for the rkt.nix expression can be found on [GitHub][rkt-nixos]

--- a/Documentation/distributions.md
+++ b/Documentation/distributions.md
@@ -104,7 +104,7 @@ virtualisation.rkt.enable = true;
 Using the nix package manager on another OS you can use:
 
 ```
-nix-env -iA nixos.rkt
+nix-env -iA nixpkgs.rkt
 ```
 
 The source for the rkt.nix expression can be found on [GitHub][rkt-nixos]


### PR DESCRIPTION
Using `nix-env` you have two options:
`nix-env -i rkt` or `nix-env -iA nixos.rkt`

Using `nix-env -iA rkt` will usually not work.

On NixOS however you also want general virtualization dependencies.
Therefore enabling the rkt virtualisation is the right way to
set up everything correctly.