### PR TITLE
rkt: add AWS auth headerer support to `rkt config`

### DIFF
--- a/rkt/config/auth.go
+++ b/rkt/config/auth.go
@@ -108,9 +108,7 @@ func (h *oAuthBearerTokenHeaderer) SignRequest(r *http.Request) *http.Request {
 }
 
 type awsAuthHeaderer struct {
-	accessKeyID     string
-	secretAccessKey string
-	region          string
+	auth awsV1
 }
 
 func (h *awsAuthHeaderer) GetHeader() http.Header {
@@ -118,7 +116,7 @@ func (h *awsAuthHeaderer) GetHeader() http.Header {
 }
 
 func (h *awsAuthHeaderer) SignRequest(r *http.Request) *http.Request {
-	region := h.region
+	region := h.auth.Region
 
 	var body io.ReadSeeker
 	if r.Body != nil {
@@ -134,7 +132,7 @@ func (h *awsAuthHeaderer) SignRequest(r *http.Request) *http.Request {
 			SigningName:   awsS3Service,
 		},
 		Config: aws.Config{
-			Credentials: credentials.NewStaticCredentials(h.accessKeyID, h.secretAccessKey, ""),
+			Credentials: credentials.NewStaticCredentials(h.auth.AccessKeyID, h.auth.SecretAccessKey, ""),
 		},
 		HTTPRequest: r,
 		Body:        body,
@@ -243,9 +241,7 @@ func (p *authV1JsonParser) getAWSV1Headerer(raw json.RawMessage) (Headerer, erro
 		return nil, fmt.Errorf("no AWS Secret Access Key specified")
 	}
 	return &awsAuthHeaderer{
-		accessKeyID:     aws.AccessKeyID,
-		secretAccessKey: aws.SecretAccessKey,
-		region:          aws.Region,
+		auth: aws,
 	}, nil
 }
 

--- a/rkt/config/config.go
+++ b/rkt/config/config.go
@@ -81,6 +81,9 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 		case *oAuthBearerTokenHeaderer:
 			typ = "oauth"
 			credentials = h.auth
+		case *awsAuthHeaderer:
+			typ = "aws"
+			credentials = h.auth
 		default:
 			return nil, errors.New("unknown headerer type")
 		}


### PR DESCRIPTION
This refactors awsAuthHeaderer to match oAuthBearerTokenHeaderer and modifies
the `config` command so awsAuthHeaderer can be marshaled to JSON (support for
this was previously missing).