### PR TITLE
Start local docker image tarball directly with `rkt run`

### DIFF
--- a/pkg/distribution/dockerarchive.go
+++ b/pkg/distribution/dockerarchive.go
@@ -1,0 +1,98 @@
+// Copyright 2018 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/PuerkitoBio/purell"
+)
+
+const (
+	distDockerArchiveVersion = 0
+
+	// TypeDocker represents the DockerArchive distribution type
+	TypeDockerArchive Type = "docker-archive"
+)
+
+func init() {
+	Register(TypeDockerArchive, NewDockerArchive)
+}
+
+// DockerArchive defines a distribution using local docker tarball
+// The format is:
+// cimd:docker-archive:v=0:ArchivePath...
+// ArchivePath must be query escaped
+// Examples:
+// cimd:docker-archive:v=0:file%3A%2F%2Fabsolute%2Fpath%2Fto%2Ffile
+type DockerArchive struct {
+	cimdURL *url.URL // the cimd URL as explained in the examples
+	fileURL string   // the local path of the target docker archive, i.e. file://path/to/file.tar
+}
+
+// NewDockerArchive creates a new docker distribution from the provided distribution uri string
+func NewDockerArchive(u *url.URL) (Distribution, error) {
+	dp, err := parseCIMD(u)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse URI: %q: %v", u.String(), err)
+	}
+	if dp.Type != TypeDockerArchive {
+		return nil, fmt.Errorf("wrong distribution type: %q", dp.Type)
+	}
+
+	path, err := url.QueryUnescape(dp.Data)
+
+	// save the URI as sorted to make it ready for comparison
+	purell.NormalizeURL(u, purell.FlagSortQuery)
+
+	return &DockerArchive{
+		cimdURL: u,
+		fileURL: path,
+	}, nil
+}
+
+// NewDockerArchiveFromString creates a new docker distribution from the provided
+// tarball path (like "some/path/to/busybox.tar" etc...)
+func NewDockerArchiveFromString(ds string) (Distribution, error) {
+	urlStr := NewCIMDString(TypeDockerArchive, distDockerArchiveVersion, url.QueryEscape(ds))
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	return NewDockerArchive(u)
+}
+
+func (d *DockerArchive) CIMD() *url.URL {
+	// Create a copy of the URL.
+	u, err := url.Parse(d.cimdURL.String())
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func (d *DockerArchive) Equals(dist Distribution) bool {
+	a2, ok := dist.(*DockerArchive)
+	if !ok {
+		return false
+	}
+
+	return d.CIMD().String() == a2.CIMD().String()
+}
+
+func (d *DockerArchive) String() string {
+	return d.fileURL
+}

--- a/pkg/distribution/dockerarchive.go
+++ b/pkg/distribution/dockerarchive.go
@@ -43,7 +43,7 @@ type DockerArchive struct {
 	fileURL string   // the local path of the target docker archive, i.e. file://path/to/file.tar
 }
 
-// NewDockerArchive creates a new docker distribution from the provided distribution uri string
+// NewDockerArchive creates a new docker-archive distribution from the provided uri string
 func NewDockerArchive(u *url.URL) (Distribution, error) {
 	dp, err := parseCIMD(u)
 	if err != nil {
@@ -64,7 +64,7 @@ func NewDockerArchive(u *url.URL) (Distribution, error) {
 	}, nil
 }
 
-// NewDockerArchiveFromString creates a new docker distribution from the provided
+// NewDockerArchiveFromString creates a new docker-archive distribution from the provided
 // tarball path (like "some/path/to/busybox.tar" etc...)
 func NewDockerArchiveFromString(ds string) (Distribution, error) {
 	urlStr := NewCIMDString(TypeDockerArchive, distDockerArchiveVersion, url.QueryEscape(ds))

--- a/pkg/distribution/dockerarchive_test.go
+++ b/pkg/distribution/dockerarchive_test.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package distribution
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestDockerArchive(t *testing.T) {
+	tests := []struct {
+		fileURL      string
+		expectedCIMD string
+	}{
+		{
+			"file:///full/path/to/busybox.tar",
+			"cimd:docker-archive:v=0:file%3A%2F%2F%2Ffull%2Fpath%2Fto%2Fbusybox.tar",
+		},
+	}
+
+	for _, tt := range tests {
+		d, err := NewDockerArchiveFromString(tt.fileURL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		u, err := url.Parse(tt.expectedCIMD)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		td, err := NewDockerArchive(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !d.Equals(td) {
+			t.Fatalf("expected identical distribution but got %q != %q", td.CIMD().String(), d.CIMD().String())
+		}
+	}
+}

--- a/rkt/image/dockerarchivefetcher.go
+++ b/rkt/image/dockerarchivefetcher.go
@@ -1,0 +1,113 @@
+// Copyright 2018 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package image
+
+import (
+	"fmt"
+	rktflag "github.com/rkt/rkt/rkt/flag"
+	"github.com/rkt/rkt/store/imagestore"
+	"net/url"
+
+	"errors"
+	"github.com/appc/docker2aci/lib"
+	d2acommon "github.com/appc/docker2aci/lib/common"
+	"github.com/hashicorp/errwrap"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// dockerArchiveFetcher is used to fetch images from local tarballs. It uses
+// a docker2aci library to perform this task.
+type dockerArchiveFetcher struct {
+	InsecureFlags *rktflag.SecFlags
+	S             *imagestore.Store
+	Debug         bool
+}
+
+// Hash uses docker2aci to convert docker archive to
+// ACI, then stores it in the store and returns the hash.
+func (f *dockerArchiveFetcher) Hash(archivePath string) (string, error) {
+	ensureLogger(f.Debug)
+	u, err := url.Parse(archivePath)
+	if err != nil {
+		return "", errwrap.Wrap(fmt.Errorf("failed to parse given path %q", archivePath), err)
+	}
+
+	p, err := filepath.Abs(u.Path)
+	if err != nil {
+		return "", errwrap.Wrap(fmt.Errorf("failed to get an absolute path for %q", u.Path), err)
+	}
+
+	return f.fetchImageFromArchive(p)
+}
+
+func (f *dockerArchiveFetcher) fetchImageFromArchive(path string) (string, error) {
+	diag.Printf("converting docker archive at %s to ACI", path)
+	aciFile, err := f.convertToACI(path)
+	if err != nil {
+		return "", err
+	}
+
+	defer aciFile.Close()
+
+	key, err := f.S.WriteACI(aciFile, imagestore.ACIFetchInfo{
+		Latest: false,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return key, nil
+}
+
+func (f *dockerArchiveFetcher) convertToACI(path string) (*os.File, error) {
+	tmpDir, err := f.getTmpDir()
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	config := docker2aci.FileConfig{
+		CommonConfig: docker2aci.CommonConfig{
+			Squash:      true,
+			OutputDir:   tmpDir,
+			TmpDir:      tmpDir,
+			Compression: d2acommon.NoCompression,
+		},
+		DockerURL: "", // Default value for -image flag
+		// TODO: Support for command line flags supported by docker2aci (?)
+	}
+
+	acis, err := docker2aci.ConvertSavedFile(path, config)
+	if err != nil {
+		return nil, errwrap.Wrap(errors.New("error converting docker image to ACI"), err)
+	}
+
+	aciFile, err := os.Open(acis[0])
+	if err != nil {
+		return nil, errwrap.Wrap(errors.New("error opening squashed ACI file"), err)
+	}
+
+	return aciFile, nil
+}
+
+func (f *dockerArchiveFetcher) getTmpDir() (string, error) {
+	storeTmpDir, err := f.S.TmpDir()
+	if err != nil {
+		return "", errwrap.Wrap(errors.New("error creating temporary dir for docker to ACI conversion"), err)
+	}
+	return ioutil.TempDir(storeTmpDir, "docker2aci-")
+}

--- a/rkt/image/fetcher.go
+++ b/rkt/image/fetcher.go
@@ -175,6 +175,8 @@ func (f *Fetcher) fetchSingleImage(db *distBundle, a *asc) (string, error) {
 		return f.fetchSingleImageByName(db, a)
 	case *dist.Docker:
 		return f.fetchSingleImageByDockerURL(v)
+	case *dist.DockerArchive:
+		return f.fetchDockerArchive(v)
 	default:
 		return "", fmt.Errorf("unknown distribution type %T", v)
 	}
@@ -361,4 +363,13 @@ func (f *Fetcher) maybeFetchImageFromRemote(db *distBundle, a *asc) (string, err
 		return nf.Hash(app, a)
 	}
 	return "", nil
+}
+
+func (f *Fetcher) fetchDockerArchive(a *dist.DockerArchive) (string, error) {
+	ff := &dockerArchiveFetcher{
+		InsecureFlags: f.InsecureFlags,
+		S:             f.S,
+		Debug:         f.Debug,
+	}
+	return ff.Hash(a.String())
 }


### PR DESCRIPTION
If a path to Docker image tarball is given with `docker://`, rkt will convert the tarball to ACI and launch the container.

To start a local docker image, run `rkt run --insecure-options=image docker://path/to/busybox.tar`. To determine if the input string is a image name or path, I'm using the heuristics in `guessAppcOrPath` (now refactored to `guessImageOrPath`). I've added test cases for this; they're working as expected.

I created a new distribution `docker-archive` and a fetcher `dockerArchiveFetcher`. The fetcher calls `docker2aci.ConvertSavedFile` on the file path and writes the ACI to `imagestore`.

Right now, only a tarball file with .tar extension is supported. Docker does not seem to care about the extension but, as of now, the documentation for `docker save` has `.tar` in the examples. `docker2aci` provides flags to deal with compression; it is not supported.

 Fixes #2392 