### PR TITLE
stage1: escape '%' in command lines as well as '$'

### DIFF
--- a/stage1/init/common/pod.go
+++ b/stage1/init/common/pod.go
@@ -55,6 +55,7 @@ func execEscape(i int, str string) string {
 
 	if i > 0 { // These are escaped only after the first argument
 		escapeMap[`$`] = `$`
+		escapeMap[`%`] = `%`
 	}
 
 	escArg := fmt.Sprintf("%q", str)

--- a/stage1/init/common/pod_test.go
+++ b/stage1/init/common/pod_test.go
@@ -56,6 +56,9 @@ func TestQuoteExec(t *testing.T) {
 			input:  []string{`$path$`, `$argument`},
 			output: `"$path$" "$$argument"`,
 		}, {
+			input:  []string{`%path%`, `%argument`},
+			output: `"%path%" "%%argument"`,
+		}, {
 			input:  []string{`path`, `Args\nwith\nnewlines`},
 			output: `"path" "Args\\nwith\\nnewlines"`,
 		}, {


### PR DESCRIPTION
systemd substitutes both %-specifiers and $-variables starting from the
second command-line argument, and rkt should escape both of them.

Fixes #3925