### PR TITLE
config: add tests for a couple documented configs

### DIFF
--- a/rkt/config/auth.go
+++ b/rkt/config/auth.go
@@ -18,15 +18,16 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client/metadata"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/private/signer/v4"
-	"io"
-	"net/http"
-	"strings"
-	"time"
 )
 
 const (

--- a/rkt/config/config.go
+++ b/rkt/config/config.go
@@ -16,7 +16,6 @@ package config
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -85,7 +84,7 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 			typ = "aws"
 			credentials = h.auth
 		default:
-			return nil, errors.New("unknown headerer type")
+			return nil, fmt.Errorf("unknown headerer type: %T", auth)
 		}
 
 		auth := struct {

--- a/rkt/config/config.go
+++ b/rkt/config/config.go
@@ -316,10 +316,7 @@ func readFile(config *Config, info os.FileInfo, path string, kinds []string) err
 	} else if !valid {
 		return nil
 	}
-	if err := parseConfigFile(config, path, kinds); err != nil {
-		return err
-	}
-	return nil
+	return parseConfigFile(config, path, kinds)
 }
 
 func validConfigFile(info os.FileInfo) (bool, error) {

--- a/rkt/config/config_test.go
+++ b/rkt/config/config_test.go
@@ -321,3 +321,24 @@ func writeBasicConfig(path, domain, user, pass string) error {
 	}
 	return ioutil.WriteFile(path, raw, 0600)
 }
+
+// TestFiles loads the fixtures in 'testfiles' and makes sure each can be
+// parsed as a valid config without panicing.
+func TestFiles(t *testing.T) {
+	dirs, err := ioutil.ReadDir("./testfiles")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range dirs {
+		if !dir.IsDir() {
+			continue
+		}
+
+		t.Run("fixture-"+filepath.Base(dir.Name()), func(t *testing.T) {
+			_, err := GetConfigFrom(filepath.Join("testfiles", dir.Name()))
+			if err != nil {
+				t.Errorf("error getting config: %v", err)
+			}
+		})
+	}
+}

--- a/rkt/config/testfiles/docker-auth/auth.d/docker.json
+++ b/rkt/config/testfiles/docker-auth/auth.d/docker.json
@@ -1,0 +1,9 @@
+{
+	"rktKind": "dockerAuth",
+	"rktVersion": "v1",
+	"registries": ["registry-1.docker.io", "quay.io"],
+	"credentials": {
+		"user": "foo",
+		"password": "bar"
+	}
+}

--- a/rkt/config/testfiles/override-auth/auth.d/coreos.json
+++ b/rkt/config/testfiles/override-auth/auth.d/coreos.json
@@ -1,0 +1,10 @@
+{
+	"rktKind": "auth",
+	"rktVersion": "v1",
+	"domains": ["coreos.com"],
+	"type": "basic",
+	"credentials": {
+		"user": "foo",
+		"password": "bar"
+	}
+}

--- a/rkt/config/testfiles/override-auth/auth.d/specific-tectonic.json
+++ b/rkt/config/testfiles/override-auth/auth.d/specific-tectonic.json
@@ -1,0 +1,9 @@
+{
+	"rktKind": "auth",
+	"rktVersion": "v1",
+	"domains": ["tectonic.com"],
+	"type": "oauth",
+	"credentials": {
+		"token": "tectonic-token"
+	}
+}

--- a/rkt/config/testfiles/s3/auth.d/s3.json
+++ b/rkt/config/testfiles/s3/auth.d/s3.json
@@ -1,0 +1,11 @@
+{
+  "rktKind": "auth",
+  "rktVersion": "v1",
+  "domains": ["my-s3-bucket.s3.amazonaws.com"],
+  "type": "aws",
+  "credentials": {
+    "accessKeyID": "foo",
+    "secretAccessKey": "bar",
+    "awsRegion": "us-east-1"
+  }
+}


### PR DESCRIPTION
These tests additions were prompted by issue #3916.

Ideally all documented configs would be included here (possibly via living outside of the docs and having the copy in the docs be templated in or such).