### PR TITLE
 tests: ensure / is mounted shared on semaphore 

### DIFF
--- a/tests/build-and-run-tests.sh
+++ b/tests/build-and-run-tests.sh
@@ -47,6 +47,11 @@ function semaphoreCIConfiguration {
     SRC_CHANGES=$(git diff-tree --no-commit-id --name-only -r HEAD..${BRANCHING_POINT} | grep -cEv ${DOC_CHANGE_PATTERN}) || true
     DOC_CHANGES=$(git diff-tree --no-commit-id --name-only -r HEAD..${BRANCHING_POINT} | grep -cE ${DOC_CHANGE_PATTERN}) || true
 
+    # semaphore's ubuntu 14.04 environment doesn't reliably have / as a shared
+    # mount. rkt's "app sandbox" tests require the datadir to be in a shared
+    # mount.
+    sudo mount --make-shared /
+
     # Set up go environment on Semaphore
     if [ -f /opt/change-go-version.sh ]; then
         . /opt/change-go-version.sh

--- a/tests/rkt_cat_manifest_test.go
+++ b/tests/rkt_cat_manifest_test.go
@@ -83,7 +83,7 @@ func TestCatManifest(t *testing.T) {
 			if err := ioutil.WriteFile(uuidFilePath, []byte(podUUID), 0600); err != nil {
 				panic(fmt.Sprintf("Cannot write pod UUID to uuid-file: %v", err))
 			}
-			runCmd := fmt.Sprintf("%s cat-manifest --uuid-file=%s --pretty-print=false %s", ctx.Cmd(), uuidFilePath)
+			runCmd := fmt.Sprintf("%s cat-manifest --uuid-file=%s --pretty-print=false", ctx.Cmd(), uuidFilePath)
 			t.Logf("Running test #%d", i)
 			runRktAndCheckRegexOutput(t, runCmd, tt.match)
 		} else {

--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -62,7 +62,7 @@ func expectCommon(p *gexpect.ExpectSubprocess, searchString string, timeout time
 		err = p.ExpectTimeout(searchString, timeout)
 	}
 	if err != nil {
-		return fmt.Errorf(string(p.Collect()))
+		return fmt.Errorf("error matching output: %v: remainder: %v", err, string(p.Collect()))
 	}
 
 	return nil

--- a/tests/rkt_volume_mount_test.go
+++ b/tests/rkt_volume_mount_test.go
@@ -65,7 +65,7 @@ func prepareTmpDirWithRecursiveMountsAndFiles(t *testing.T) []func() {
 
 	if _, err := tmpdir2outerfile.WriteString(outerFileContent); err != nil {
 		executeFuncsReverse(cleanupFuncs)
-		t.Fatalf("Can't write to file %q after mounting: %v", tmpdir2outerfile, err)
+		t.Fatalf("Can't write to file %q after mounting: %v", tmpdir2outerfile.Name(), err)
 	}
 
 	// mount tmpfs for /dir1/subDirRW
@@ -90,7 +90,7 @@ func prepareTmpDirWithRecursiveMountsAndFiles(t *testing.T) []func() {
 
 	if _, err := tmpdir2innerfile.WriteString(innerFileContent); err != nil {
 		executeFuncsReverse(cleanupFuncs)
-		t.Fatalf("Can't write to file %q after mounting: %v", tmpdir2innerfile, err)
+		t.Fatalf("Can't write to file %q after mounting: %v", tmpdir2innerfile.Name(), err)
 	}
 
 	return cleanupFuncs


### PR DESCRIPTION
This fixes the `coreos` flavor failure semaphore is having. I think `kvm` still has issues, so this might still fail there.

See #3940 for the more general issue, this is just to get master back to passing without truly addressing the root issue.

I also included some minor changes which I made while investigating this since they're quite trivial.