### PR TITLE
rkt: add fixes to build with gccgo

### DIFF
--- a/common/arm_gc.go
+++ b/common/arm_gc.go
@@ -1,0 +1,23 @@
+// Copyright 2014 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gc
+
+package common
+
+import _ "unsafe" // for go:linkname
+
+// reference to GOARM, needs to be globally, if in GetArch() function it resolves to zero
+//go:linkname goarm runtime.goarm
+var goarm uint8

--- a/common/arm_gccgo.go
+++ b/common/arm_gccgo.go
@@ -1,0 +1,20 @@
+// Copyright 2014 The rkt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build gccgo
+
+package common
+
+// gccgo doesn't use GOARM.  Not clear that it matters.
+var goarm uint8

--- a/common/common.go
+++ b/common/common.go
@@ -526,10 +526,6 @@ func GetArch() string {
 	return arch
 }
 
-// reference to GOARM, needs to be globally, if in GetArch() function it resolves to zero
-//go:linkname goarm runtime.goarm
-var goarm uint8
-
 func GetOSArch() (os string, arch string) {
 	arch = runtime.GOARCH
 	flavor := ""

--- a/store/imagestore/main_test.go
+++ b/store/imagestore/main_test.go
@@ -28,7 +28,7 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "created by testing.RunTests") ||
 			strings.Contains(stack, "testing.Main(") ||
 			strings.Contains(stack, "runtime.goexit") ||
-			strings.Contains(stack, "github.com/rkt/rkt/store/imagestore.interestingGoroutines") ||
+			strings.Contains(stack, "imagestore.interestingGoroutines") ||
 			strings.Contains(stack, "created by runtime.gc") ||
 			strings.Contains(stack, "runtime.MHeap_Scavenger") {
 			continue

--- a/vendor/github.com/klauspost/compress/flate/crc32_amd64.go
+++ b/vendor/github.com/klauspost/compress/flate/crc32_amd64.go
@@ -1,5 +1,6 @@
 //+build !noasm
 //+build !appengine
+//+build !gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 

--- a/vendor/github.com/klauspost/compress/flate/crc32_amd64.s
+++ b/vendor/github.com/klauspost/compress/flate/crc32_amd64.s
@@ -1,4 +1,5 @@
 //+build !noasm !appengine
+//+build !gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 

--- a/vendor/github.com/klauspost/compress/flate/crc32_noasm.go
+++ b/vendor/github.com/klauspost/compress/flate/crc32_noasm.go
@@ -1,4 +1,4 @@
-//+build !amd64 noasm appengine
+//+build !amd64 noasm appengine gccgo
 
 // Copyright 2015, Klaus Post, see LICENSE for details.
 

--- a/vendor/golang.org/x/sys/unix/gccgo.go
+++ b/vendor/golang.org/x/sys/unix/gccgo.go
@@ -6,7 +6,10 @@
 
 package unix
 
-import "syscall"
+import (
+	"syscall"
+	"unsafe"
+)
 
 // We can't use the gc-syntax .s files for gccgo.  On the plus side
 // much of the functionality can be written directly in Go.
@@ -44,3 +47,6 @@ func RawSyscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err sysc
 	r, errno := realSyscall(trap, a1, a2, a3, a4, a5, a6, 0, 0, 0)
 	return r, 0, syscall.Errno(errno)
 }
+
+//go:noinline
+func use(unsafe.Pointer) {}

--- a/vendor/golang.org/x/sys/unix/gccgo_c.c
+++ b/vendor/golang.org/x/sys/unix/gccgo_c.c
@@ -30,12 +30,3 @@ gccgoRealSyscall(uintptr_t trap, uintptr_t a1, uintptr_t a2, uintptr_t a3, uintp
 	r.err = errno;
 	return r;
 }
-
-// Define the use function in C so that it is not inlined.
-
-extern void use(void *) __asm__ (GOSYM_PREFIX GOPKGPATH ".use") __attribute__((noinline));
-
-void
-use(void *p __attribute__ ((unused)))
-{
-}

--- a/vendor/golang.org/x/sys/unix/syscall.go
+++ b/vendor/golang.org/x/sys/unix/syscall.go
@@ -21,8 +21,6 @@
 // holds a value of type syscall.Errno.
 package unix // import "golang.org/x/sys/unix"
 
-import "unsafe"
-
 // ByteSliceFromString returns a NUL-terminated slice of bytes
 // containing the text of s. If s contains a NUL byte at any
 // location, it returns (nil, EINVAL).
@@ -69,8 +67,3 @@ func (tv *Timeval) Nano() int64 {
 }
 
 func TimevalToNsec(tv Timeval) int64 { return int64(tv.Sec)*1e9 + int64(tv.Usec)*1e3 }
-
-// use is a no-op, but the compiler cannot see that it is.
-// Calling use(p) ensures that p is kept live until that point.
-//go:noescape
-func use(p unsafe.Pointer)

--- a/vendor/golang.org/x/sys/unix/syscall_linux_amd64.go
+++ b/vendor/golang.org/x/sys/unix/syscall_linux_amd64.go
@@ -6,8 +6,6 @@
 
 package unix
 
-import "syscall"
-
 //sys	Dup2(oldfd int, newfd int) (err error)
 //sys	EpollWait(epfd int, events []EpollEvent, msec int) (n int, err error)
 //sys	Fadvise(fd int, offset int64, length int64, advice int) (err error) = SYS_FADVISE64
@@ -62,9 +60,6 @@ import "syscall"
 //sys	recvmsg(s int, msg *Msghdr, flags int) (n int, err error)
 //sys	sendmsg(s int, msg *Msghdr, flags int) (n int, err error)
 //sys	mmap(addr uintptr, length uintptr, prot int, flags int, fd int, offset int64) (xaddr uintptr, err error)
-
-//go:noescape
-func gettimeofday(tv *Timeval) (err syscall.Errno)
 
 func Gettimeofday(tv *Timeval) (err error) {
 	errno := gettimeofday(tv)

--- a/vendor/golang.org/x/sys/unix/syscall_linux_amd64_gc.go
+++ b/vendor/golang.org/x/sys/unix/syscall_linux_amd64_gc.go
@@ -1,0 +1,13 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build amd64,linux
+// +build !gccgo
+
+package unix
+
+import "syscall"
+
+//go:noescape
+func gettimeofday(tv *Timeval) (err syscall.Errno)

--- a/vendor/golang.org/x/sys/unix/syscall_unix.go
+++ b/vendor/golang.org/x/sys/unix/syscall_unix.go
@@ -49,11 +49,6 @@ func errnoErr(e syscall.Errno) error {
 	return e
 }
 
-func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno)
-func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
-func RawSyscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno)
-func RawSyscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
-
 // Mmap manager, for use by operating system-specific implementations.
 
 type mmapper struct {

--- a/vendor/golang.org/x/sys/unix/syscall_unix_gc.go
+++ b/vendor/golang.org/x/sys/unix/syscall_unix_gc.go
@@ -1,0 +1,23 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+// +build !gccgo
+
+package unix
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno)
+func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
+func RawSyscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno)
+func RawSyscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
+
+// use is a no-op, but the compiler cannot see that it is.
+// Calling use(p) ensures that p is kept live until that point.
+//go:noescape
+func use(p unsafe.Pointer)


### PR DESCRIPTION
Replaces pull request #3962, which did a full update of github.com/klauspost/compress/flate and golang.org/x/sys/unix, which failed to build with older versions of Go.  Instead just cherrypick the changes required for gccgo support.

Updates golang/go#28670