### PR TITLE
Expose raw ports using docker2aci style port syntax

### DIFF
--- a/common/networking/ports.go
+++ b/common/networking/ports.go
@@ -54,9 +54,9 @@ func findAppPort(manifest *schema.PodManifest, portName types.ACName) (*types.Po
 // be used to specify raw ports.  Used for opening ports to the container when
 // the ports needed are only known at runtime (versus at container build time).
 func getRawPort(manifest *schema.PodManifest, portName types.ACName) *types.Port {
-	validRawPortName = regexp.MustCompile("^[0-9]{1,5}-(tcp|udp){1}$")
-	validProtocol = regexp.MustCompile("(tcp|udp)")
-	validPortNum = regexp.MustCompile("[0-9]{1,5}")
+	validRawPortName := regexp.MustCompile("^[0-9]{1,5}-(tcp|udp){1}$")
+	validProtocol := regexp.MustCompile("(tcp|udp)")
+	validPortNum := regexp.MustCompile("[0-9]{1,5}")
 
 	nameStr := portName.String()
 
@@ -65,15 +65,16 @@ func getRawPort(manifest *schema.PodManifest, portName types.ACName) *types.Port
 		return nil
 	}
 
-	if portNum, err := strconv.ParseUint(validPortNum.FindString(nameStr), 10, 16); err != nil {
+	portNum, err := strconv.ParseUint(validPortNum.FindString(nameStr), 10, 16)
+	if err != nil {
 		return nil
 	}
 
 	portProto := validProtocol.FindString(nameStr)
 	rawPort := types.Port{
-		Name: portName,
+		Name:     portName,
 		Protocol: portProto,
-		Port: portNum,
+		Port:     uint(portNum),
 	}
 	return &rawPort
 }


### PR DESCRIPTION
This change was created to allow ports to be exposed without being in the image manifest.  It uses the same syntax as generated manifests from docker2aci (e.g. '80-tcp', etc).  Motivation is for running Envoy as a sidecar -- which discovers the ports it listens on at run-time rather than at image build time.

Happy to add tests + docs or change strategy if desired.  I wanted to use OCI syntax as suggested in #2113 but this requires a change to [ACName](https://github.com/appc/spec/blob/master/schema/types/acname.go#L26).  The advantage of that approach is not overloading the docker syntax -- wherein people may get confused that a docker image port has changed and they no longer get an error but instead have exposed a raw port.  I'm happy to pursue that route as well.

I'm not opposed to other strategies such as #3407 but am concerned it appeared to have died on the vine.  Rkt's native pod support is an excellent feature for doing sidecars right at the runtime layer and I really want to see service mesh sidecars like Envoy compatible with Rkt.