### PR TITLE
Update yifan's email

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -6,4 +6,4 @@ Euan Kemp <euank@euank.com> (@euank) pkg: *
 Iago López Galeiras <iago@kinvolk.io> (@iaguis) pkg: *
 Krzesimir Nowak <krzesimir@kinvolk.io> (@krnowak) pkg: *
 Luca Bruno <luca.bruno@coreos.com> (@lucab) pkg: *
-Yifan Gu <yifan.gu@coreos.com> (@yifan-gu) pkg: *
+Yifan Gu <guyifan1121@gmail.com> (@yifan-gu) pkg: *


### PR DESCRIPTION
The yifan.gu@coreos.com email is no longer valid.