### PR TITLE
Adding '/usr/bin/env bash' as a shebang line in cache.sh

### DIFF
--- a/stage1/usr_from_coreos/cache.sh
+++ b/stage1/usr_from_coreos/cache.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e;
 
 # maintain a cached copy of coreos pxe image


### PR DESCRIPTION
This commit aims to add  shebang line that indicates scripts use
bash shell for interpreting

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>