### PR TITLE
Remove unused functions

### DIFF
--- a/tests/rkt_tests.go
+++ b/tests/rkt_tests.go
@@ -319,22 +319,6 @@ func patchImportAndFetchHash(image string, patches []string, t *testing.T, ctx *
 	return importImageAndFetchHash(t, ctx, "", imagePath)
 }
 
-func patchImportAndRun(image string, patches []string, t *testing.T, ctx *testutils.RktRunCtx) {
-	imagePath := patchTestACI(image, patches...)
-	defer os.Remove(imagePath)
-
-	cmd := fmt.Sprintf("%s --insecure-options=image run %s", ctx.Cmd(), imagePath)
-	spawnAndWaitOrFail(t, cmd, 0)
-}
-
-func patchImportAndPrepare(image string, patches []string, t *testing.T, ctx *testutils.RktRunCtx) {
-	imagePath := patchTestACI(image, patches...)
-	defer os.Remove(imagePath)
-
-	cmd := fmt.Sprintf("%s --insecure-options=image prepare %s", ctx.Cmd(), imagePath)
-	spawnAndWaitOrFail(t, cmd, 0)
-}
-
 func runGC(t *testing.T, ctx *testutils.RktRunCtx) {
 	cmd := fmt.Sprintf("%s gc --grace-period=0s", ctx.Cmd())
 	spawnAndWaitOrFail(t, cmd, 0)


### PR DESCRIPTION
Remove patchImportAndRun, patchImportAndPrepare functions unused in rkt_test.go