### PR TITLE
changing package name causing build failure.

### DIFF
--- a/tests/install-deps.sh
+++ b/tests/install-deps.sh
@@ -20,7 +20,7 @@ if [ "${CI-}" == true ] ; then
 		# Semaphore installs more dependencies on their
 		# platform, they should be removed from here to save time.
 
-		install-package libacl1-dev bc libsystemd-journal-dev
+		install-package libacl1-dev bc libsystemd-dev
 
 		# libmount: https://github.com/systemd/systemd/pull/986#issuecomment-138451264
 		sudo add-apt-repository --yes ppa:pitti/systemd-semaphore


### PR DESCRIPTION
changing package name from libsystemd-journal-dev to libsystemd-dev.
this has caused because in semaphoreci Ubuntu version bumped up from trusty to xenial.