### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/dist/init/systemd/rkt-api.service
+++ b/dist/init/systemd/rkt-api.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=rkt api service
-Documentation=http://github.com/rkt/rkt
+Documentation=https://github.com/rkt/rkt
 After=network.target rkt-api-tcp.socket
 Requires=rkt-api-tcp.socket
 

--- a/dist/init/systemd/rkt-metadata.service
+++ b/dist/init/systemd/rkt-metadata.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=rkt metadata service
-Documentation=http://github.com/rkt/rkt
+Documentation=https://github.com/rkt/rkt
 After=network.target rkt-metadata.socket
 Requires=rkt-metadata.socket
 


### PR DESCRIPTION
Currently, when we access github.com with HTTP, it is redirected to HTTPS automatically. So this commit aims to replace http://github.com by https://github.com for security.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>